### PR TITLE
Modify the interface of enumerations

### DIFF
--- a/lib/enumeration.ml
+++ b/lib/enumeration.ml
@@ -1,60 +1,68 @@
-type 'a mutable_list = Nil | Cons of 'a * 'a mutable_list ref
+type 'a mutable_stream = (unit -> 'a node) ref
+ and 'a node =
+   | Nil
+   | Cons of 'a * 'a mutable_stream
 
-(* 与えられたリストからn要素を選ぶ順列を列挙 *)
-let perm : int -> 'a list -> 'a list list = fun n xs ->
-  let head = ref Nil in
-  (* xsを変更可能なリストに変換 *)
-  ignore (List.fold_left (fun tail x ->
-    let tail' = ref Nil in
-    tail := Cons (x, tail'); tail') head xs);
-  let rec perm_aux ys n ptr acc =
+let perm n xs =
+  let rec mutable_stream_of_list xs =
+    ref @@ fun () ->
+    match xs with
+    | [] -> Nil
+    | x :: xs -> Cons (x, mutable_stream_of_list xs) in
+  let head = mutable_stream_of_list xs in
+  let rec perm_aux xs n ptr acc () =
     if n <= 0
-    then ys :: acc
-    else match !ptr with
-         | Nil -> acc
-         | (Cons (x, next)) as here ->
-             let acc = perm_aux ys n next acc in
-             ptr := !next; (* リストからconsセルhereを削除 *)
-             (* consセルを削除したリストから，n-1要素を選ぶ *)
-             let acc = perm_aux (x :: ys) (n - 1) head acc in
-             ptr := here; (* consセルを戻す *)
-             acc in
-  perm_aux [] n head []
+    then Seq.Cons (xs, acc)
+    else
+      match !ptr () with
+      | Nil -> acc ()
+      | (Cons (x, next)) as here ->
+          (* ストリームからxを取り除く *)
+          ptr := !next;
+          (* まずxを取り除いたストリームからn-1要素を選ぶ *)
+          perm_aux (x :: xs) (n - 1) head
+            (fun () ->
+              (* n-1要素を選び終わったタイミングで，ストリームにxを戻す *)
+              ptr := (fun () -> here);
+              perm_aux xs n next acc ()) () in
+  perm_aux [] n head Seq.empty
 
-let rec comb acc xs n ys =
+let rec comb xs n ys acc () =
   match n, ys with
-  | 0, _ -> xs :: acc
-  | _, [] -> acc
-  | n, y :: ys -> comb (comb acc xs n ys) (y :: xs) (n - 1) ys
-(* 与えられたリストからn要素を選ぶ組み合わせを列挙 *)
-let comb : int -> 'a list -> 'a list list = fun n -> comb [] [] n
+  | 0, _ -> Seq.Cons (xs, acc)
+  | _, [] -> acc ()
+  | n, y :: ys -> comb (y :: xs) (n - 1) ys (comb xs n ys acc) ()
+(* 与えられたリストからn要素を選ぶ組み合わせをストリームとして列挙 *)
+let comb : int -> 'a list -> 'a list Seq.t = fun n xs ->
+  if n < 0 then Seq.empty else comb [] n xs Seq.empty
 
-let rec repcomb acc xs n ys =
+let rec repcomb xs n ys acc () =
   match n, ys with
-  | 0, _ -> xs :: acc
-  | _, [] -> acc
-  | n, y :: ys' -> repcomb (repcomb acc xs n ys') (y :: xs) (n - 1) ys
-(* 与えられたリストから重複を許してn要素を選ぶ組み合わせを列挙 *)
-let repcomb : int -> 'a list -> 'a list list = fun n -> repcomb [] [] n;;
+  | 0, _ -> Seq.Cons (xs, acc)
+  | _, [] -> acc ()
+  | n, y :: ys' -> repcomb (y :: xs) (n - 1) ys (repcomb xs n ys' acc) ()
+(* 与えられたリストから重複を許してn要素を選ぶ組み合わせをストリームとして列挙 *)
+let repcomb : int -> 'a list -> 'a list Seq.t = fun n xs ->
+  if n < 0 then Seq.empty else repcomb [] n xs Seq.empty;;
 
 (* sample code *)
-perm 2 [1; 2; 3; 4];;
-perm 0 [1; 2; 3];;
-perm 3 [1; 2; 3];;
-perm 4 [1; 2; 3];;
+List.of_seq @@ perm 2 [1; 2; 3; 4];;
+List.of_seq @@ perm 0 [1; 2; 3];;
+List.of_seq @@ perm 3 [1; 2; 3];;
+List.of_seq @@ perm 4 [1; 2; 3];;
 
-comb 2 [1; 2; 3];;
-comb 3 [1; 2; 3];;
-comb 0 [1; 2; 3];;
-comb 4 [1; 2; 3];;
+List.of_seq @@ comb 2 [1; 2; 3];;
+List.of_seq @@ comb 3 [1; 2; 3];;
+List.of_seq @@ comb 0 [1; 2; 3];;
+List.of_seq @@ comb 4 [1; 2; 3];;
 
-repcomb 2 [1; 2; 3];;
-repcomb 3 [1; 2; 3];;
-repcomb 0 [1; 2; 3];;
-repcomb 4 [1; 2; 3];;
+List.of_seq @@ repcomb 2 [1; 2; 3];;
+List.of_seq @@ repcomb 3 [1; 2; 3];;
+List.of_seq @@ repcomb 0 [1; 2; 3];;
+List.of_seq @@ repcomb 4 [1; 2; 3];;
 
 (* 添字の違う要素は区別される *)
-perm 2 [1; 1; 2];;
-comb 2 [1; 1; 2];;
-repcomb 2 [1; 1; 2];;
+List.of_seq @@ perm 2 [1; 1; 2];;
+List.of_seq @@ comb 2 [1; 1; 2];;
+List.of_seq @@ repcomb 2 [1; 1; 2];;
 


### PR DESCRIPTION
## Why

現在，順列などを列挙する関数は順列等のリストを返しているが，
いちいち長さnPrのリストを生成したりするとメモリ使用量がヤバい．

## What

順列とかを列挙する時にはストリームで列挙するようにした．