### PR TITLE
名前空間のリファクタリング

### DIFF
--- a/lib/containers/fenwickTree.ml
+++ b/lib/containers/fenwickTree.ml
@@ -1,57 +1,39 @@
-(* 0-indexedなBIT *)
-module FenwickTree = struct
-  (* 可換モノイド *)
-  module type CommutativeMonoid = sig
-    type t
-    val e : t
-    val op : t -> t -> t
-  end
-
-  module Make (CM : CommutativeMonoid)
-  : sig
-    type t
-    (* n要素の単位元からなるBITを作る *)
-    val make : int -> t
-    (* 添字iの要素にはf iが入ったn要素のBITを作る *)
-    val init : int -> (int -> CM.t) -> t
-    (* 与えられたリストの要素が入ったBITを作る *)
-    val of_list : CM.t list -> t
-    (* i番目の要素にxを加える *)
-    val accumulate : t -> int -> CM.t -> unit
-    (* 添字が[0, i)の範囲の要素を全て加えた値を求める *)
-    val query : t -> int -> CM.t
-  end
-  = struct
-    type t = CM.t array
-
-    let make n = Array.make n CM.e
-
-    let initialize a =
-      for i = 0 to Array.length a - 1 do
-        if i lor (i + 1) < Array.length a then
-          a.(i lor (i + 1)) <- CM.op a.(i) a.(i lor (i + 1))
-      done
-
-    let init n f =
-      let a = Array.init n f in
-      initialize a; a
-
-    let of_list l =
-      let a = Array.of_list l in
-      initialize a; a
-
-    let rec accumulate a i x =
-      if i < Array.length a then begin
-        a.(i) <- CM.op x a.(i);
-        accumulate a (i lor (i + 1)) x
-      end
-
-    let rec query acc a i =
-      if i < 0
-      then acc
-      else query (CM.op acc a.(i)) a ((i land (i + 1)) - 1)
-    let query a i = query CM.e a (i - 1)
-  end
+(* 可換モノイド *)
+module type CommutativeMonoid = sig
+  type t
+  val e : t
+  val op : t -> t -> t
 end
 
+(* 0-indexedなBIT *)
+module Make (CM : CommutativeMonoid) = struct
+  type t = CM.t array
 
+  let make n = Array.make n CM.e
+
+  let initialize a =
+    for i = 0 to Array.length a - 1 do
+      if i lor (i + 1) < Array.length a then
+        a.(i lor (i + 1)) <- CM.op a.(i) a.(i lor (i + 1))
+    done
+
+  let init n f =
+    let a = Array.init n f in
+    initialize a; a
+
+  let of_list l =
+    let a = Array.of_list l in
+    initialize a; a
+
+  let rec accumulate a i x =
+    if i < Array.length a then begin
+      a.(i) <- CM.op x a.(i);
+      accumulate a (i lor (i + 1)) x
+    end
+
+  let rec query acc a i =
+    if i < 0
+    then acc
+    else query (CM.op acc a.(i)) a ((i land (i + 1)) - 1)
+  let query a i = query CM.e a (i - 1)
+end

--- a/lib/containers/fenwickTree.mli
+++ b/lib/containers/fenwickTree.mli
@@ -1,0 +1,19 @@
+module type CommutativeMonoid = sig
+  type t
+  val e : t
+  val op : t -> t -> t
+end
+
+module Make (CM : CommutativeMonoid) : sig
+  type t
+  (* n要素の単位元からなるBITを作る *)
+  val make : int -> t
+  (* 添字iの要素にはf iが入ったn要素のBITを作る *)
+  val init : int -> (int -> CM.t) -> t
+  (* 与えられたリストの要素が入ったBITを作る *)
+  val of_list : CM.t list -> t
+  (* i番目の要素にxを加える *)
+  val accumulate : t -> int -> CM.t -> unit
+  (* 添字が[0, i)の範囲の要素を全て加えた値を求める *)
+  val query : t -> int -> CM.t
+end

--- a/lib/containers/pArray.ml
+++ b/lib/containers/pArray.ml
@@ -1,56 +1,37 @@
-module PArray : sig
-  (* persistent array *)
-  type 'a t
+type 'a t = 'a data ref
+and 'a data = Arr of 'a array | Diff of int * 'a * 'a t
 
-  val init : int -> (int -> 'a) -> 'a t
-  val make : int -> 'a -> 'a t
-  val of_list : 'a list -> 'a t
-  val get : 'a t -> int -> 'a
-  val set : 'a t -> int -> 'a -> 'a t
-  (** [set a n x] returns a persistent array replacing element number [n] of [a] with [x].
-     [a] is not modified. *)
-  val length : 'a t -> int
-  val to_list : 'a t -> 'a list
-  val iter : ('a -> unit) -> 'a t -> unit
-  val iteri : (int -> 'a -> unit) -> 'a t -> unit
-  val fold_left : ('a -> 'b -> 'a) -> 'a -> 'b t -> 'a
-  val fold_right : ('b -> 'a -> 'a) -> 'b t -> 'a -> 'a
-end = struct
-  type 'a t = 'a data ref
-  and 'a data = Arr of 'a array | Diff of int * 'a * 'a t
+let init n f = ref (Arr (Array.init n f))
+let make n v = ref (Arr (Array.make n v))
+let of_list l = ref (Arr (Array.of_list l))
 
-  let init n f = ref (Arr (Array.init n f))
-  let make n v = ref (Arr (Array.make n v))
-  let of_list l = ref (Arr (Array.of_list l))
-
-  let rec reroot k = function
-    | { contents = Arr a } -> k a
-    | { contents = Diff (i, v, t') } as t ->
-        reroot (fun a ->
-          t' := Diff (i, a.(i), t);
-          a.(i) <- v;
-          k a) t'
-  let reroot k = function
-    | { contents = Arr a } -> k a
-    | { contents = Diff (_, _, _) } as t ->
-        reroot (fun a -> t := Arr a; k a) t
-
-  let get t i = reroot (fun a -> a.(i)) t
-
-  let set t i v =
-    reroot (fun a ->
-      if v = a.(i) then t
-      else begin
-        let result = ref (Arr a) in
-        t := Diff (i, a.(i), result);
+let rec reroot k = function
+  | { contents = Arr a } -> k a
+  | { contents = Diff (i, v, t') } as t ->
+      reroot (fun a ->
+        t' := Diff (i, a.(i), t);
         a.(i) <- v;
-        result
-      end) t
+        k a) t'
+let reroot k = function
+  | { contents = Arr a } -> k a
+  | { contents = Diff (_, _, _) } as t ->
+      reroot (fun a -> t := Arr a; k a) t
 
-  let length t = reroot Array.length t
-  let to_list t = reroot Array.to_list t
-  let iter f = reroot (Array.iter f)
-  let iteri f = reroot (Array.iteri f)
-  let fold_left f x = reroot (Array.fold_left f x)
-  let fold_right f t x = reroot (fun a -> Array.fold_right f a x) t
-end
+let get t i = reroot (fun a -> a.(i)) t
+
+let set t i v =
+  reroot (fun a ->
+    if v = a.(i) then t
+    else begin
+      let result = ref (Arr a) in
+      t := Diff (i, a.(i), result);
+      a.(i) <- v;
+      result
+    end) t
+
+let length t = reroot Array.length t
+let to_list t = reroot Array.to_list t
+let iter f = reroot (Array.iter f)
+let iteri f = reroot (Array.iteri f)
+let fold_left f x = reroot (Array.fold_left f x)
+let fold_right f t x = reroot (fun a -> Array.fold_right f a x) t

--- a/lib/containers/pArray.mli
+++ b/lib/containers/pArray.mli
@@ -1,0 +1,16 @@
+(* persistent array *)
+type 'a t
+
+val init : int -> (int -> 'a) -> 'a t
+val make : int -> 'a -> 'a t
+val of_list : 'a list -> 'a t
+val get : 'a t -> int -> 'a
+val set : 'a t -> int -> 'a -> 'a t
+(** [set a n x] returns a persistent array replacing element number [n] of [a] with [x].
+   [a] is not modified. *)
+val length : 'a t -> int
+val to_list : 'a t -> 'a list
+val iter : ('a -> unit) -> 'a t -> unit
+val iteri : (int -> 'a -> unit) -> 'a t -> unit
+val fold_left : ('a -> 'b -> 'a) -> 'a -> 'b t -> 'a
+val fold_right : ('b -> 'a -> 'a) -> 'b t -> 'a -> 'a

--- a/lib/containers/pHashtbl.ml
+++ b/lib/containers/pHashtbl.ml
@@ -1,65 +1,51 @@
-module PHashtbl : sig
-  (* 永続ハッシュテーブル（は？） *)
-  type ('a, 'b) t
+type ('a, 'b) t = ('a, 'b) data ref
+(* 編集による差分 *)
+and ('a, 'b) data =
+    Hashtbl of ('a, 'b) Hashtbl.t
+  | Add of ('a, 'b) t * 'a * 'b
+  | Remove of ('a, 'b) t * 'a
 
-  val create : ?random:bool -> int -> ('a, 'b) t
-  val add : ('a, 'b) t -> 'a -> 'b -> ('a, 'b) t
-  val remove : ('a, 'b) t -> 'a -> ('a, 'b) t
-  val replace : ('a, 'b) t -> 'a -> 'b -> ('a, 'b) t
-  val find : ('a, 'b) t -> 'a -> 'b
-  val iter : ('a -> 'b -> unit) -> ('a, 'b) t -> unit
-  val fold : ('a -> 'b -> 'c -> 'c) -> ('a, 'b) t -> 'c -> 'c
-  val length : ('a, 'b) t -> int
-end = struct
-  type ('a, 'b) t = ('a, 'b) data ref
-  (* 編集による差分 *)
-  and ('a, 'b) data =
-      Hashtbl of ('a, 'b) Hashtbl.t
-    | Add of ('a, 'b) t * 'a * 'b
-    | Remove of ('a, 'b) t * 'a
+let create ?(random=false) n = ref (Hashtbl (Hashtbl.create ~random n))
 
-  let create ?(random=false) n = ref (Hashtbl (Hashtbl.create ~random n))
+(* ハッシュを使う前に，差分を解消して一番上に持ってくる *)
+let rec reroot k = function
+  | { contents = Hashtbl h } -> k h
+  | { contents = Add (t', i, d) } as t ->
+      reroot (fun h ->
+        (* 辺を逆向きに張り替える *)
+        t' := Remove (t, i);
+        Hashtbl.add h i d;
+        k h) t'
+  | { contents = Remove (t', i) } as t ->
+      reroot (fun h ->
+        (* 辺を逆向きに張り替える *)
+        t' := Add (t, i, Hashtbl.find h i);
+        Hashtbl.remove h i;
+        k h) t'
+let reroot k t =
+  reroot (fun h -> t := Hashtbl h; k h) t
 
-  (* ハッシュを使う前に，差分を解消して一番上に持ってくる *)
-  let rec reroot k = function
-    | { contents = Hashtbl h } -> k h
-    | { contents = Add (t', i, d) } as t ->
-        reroot (fun h ->
-          (* 辺を逆向きに張り替える *)
-          t' := Remove (t, i);
-          Hashtbl.add h i d;
-          k h) t'
-    | { contents = Remove (t', i) } as t ->
-        reroot (fun h ->
-          (* 辺を逆向きに張り替える *)
-          t' := Add (t, i, Hashtbl.find h i);
-          Hashtbl.remove h i;
-          k h) t'
-  let reroot k t =
-    reroot (fun h -> t := Hashtbl h; k h) t
+(* 破壊的でなかった操作は，差分を解消してからやるだけ *)
+let find t i = reroot (fun h -> Hashtbl.find h i) t
+let iter f t = reroot (Hashtbl.iter f) t
+let fold f t d = reroot (fun h -> Hashtbl.fold f h d) t
+let length t = reroot Hashtbl.length t
 
-  (* 破壊的でなかった操作は，差分を解消してからやるだけ *)
-  let find t i = reroot (fun h -> Hashtbl.find h i) t
-  let iter f t = reroot (Hashtbl.iter f) t
-  let fold f t d = reroot (fun h -> Hashtbl.fold f h d) t
-  let length t = reroot Hashtbl.length t
+(* 破壊的だった操作は，履歴を残しておく必要がある *)
+let add t i d =
+  reroot (fun h ->
+    let t' = ref (Hashtbl h) in
+    t := Remove (t', i);
+    Hashtbl.add h i d; t') t
 
-  (* 破壊的だった操作は，履歴を残しておく必要がある *)
-  let add t i d =
-    reroot (fun h ->
+let remove t i =
+  reroot (fun h ->
+    try
       let t' = ref (Hashtbl h) in
-      t := Remove (t', i);
-      Hashtbl.add h i d; t') t
+      t := Add (t', i, Hashtbl.find h i);
+      Hashtbl.remove h i; t'
+    (* 要素が存在しなかった場合，何もしないので履歴を残す必要もない *)
+    with Not_found -> t) t
 
-  let remove t i =
-    reroot (fun h ->
-      try
-        let t' = ref (Hashtbl h) in
-        t := Add (t', i, Hashtbl.find h i);
-        Hashtbl.remove h i; t'
-      (* 要素が存在しなかった場合，何もしないので履歴を残す必要もない *)
-      with Not_found -> t) t
-
-  (* 基本操作の組み合わせで表現できるもの *)
-  let replace t i d = add (remove t i) i d
-end
+(* 基本操作の組み合わせで表現できるもの *)
+let replace t i d = add (remove t i) i d

--- a/lib/containers/pHashtbl.mli
+++ b/lib/containers/pHashtbl.mli
@@ -1,0 +1,11 @@
+(* 永続ハッシュテーブル（は？） *)
+type ('a, 'b) t
+
+val create : ?random:bool -> int -> ('a, 'b) t
+val add : ('a, 'b) t -> 'a -> 'b -> ('a, 'b) t
+val remove : ('a, 'b) t -> 'a -> ('a, 'b) t
+val replace : ('a, 'b) t -> 'a -> 'b -> ('a, 'b) t
+val find : ('a, 'b) t -> 'a -> 'b
+val iter : ('a -> 'b -> unit) -> ('a, 'b) t -> unit
+val fold : ('a -> 'b -> 'c -> 'c) -> ('a, 'b) t -> 'c -> 'c
+val length : ('a, 'b) t -> int

--- a/lib/containers/pUnionFind.ml
+++ b/lib/containers/pUnionFind.ml
@@ -1,116 +1,74 @@
 (* 永続素集合データ構造 *)
-module PersistentUnionFind :
-  sig
-    module type S =
-      sig
-        type t
-        type elt
-        module Class : sig
-          (* 集合の識別子 *)
-          type t
-          val compare : t -> t -> int
-        end
-        (* 要素がどの集合に属するか調べる *)
-        val find : elt -> t -> Class.t
-        (* 与えられた集合同士を合併する *)
-        val union : Class.t -> Class.t -> t -> t
-        (* 与えられた集合に属する要素の数を求める *)
-        val cardinal : Class.t -> t -> int
-      end
-    (* 永続ハッシュテーブルを用いた実装 *)
-    module ByHashtbl : sig
-      module Make :
-        functor (Elt : Map.OrderedType) ->
-        sig
-          include S
-          (* n要素が異なる集合に属した素集合データ構造を作成 *)
-          val make : int -> t
-        end with type elt = Elt.t
-    end
-    (* Mapを用いた実装 *)
-    module ByMap : sig
-      module Make :
-        functor (Elt : Map.OrderedType) ->
-        sig
-          include S
-          (* 全ての要素が異なる集合に属した素集合データ構造を作成 *)
-          val make : unit -> t
-        end with type elt = Elt.t
-    end
+module type S = sig
+  type t
+  type elt
+  module Class : sig
+    type t
+    val compare : t -> t -> int
   end
+  val find : elt -> t -> Class.t
+  val union : Class.t -> Class.t -> t -> t
+  val cardinal : Class.t -> t -> int
+end
+
+module Core
+  (Elt : sig
+    type t
+    val compare : t -> t -> int
+  end)
+  (EMap : sig
+    type 'a t
+    val add : Elt.t -> 'a -> 'a t -> 'a t
+    val find_opt : Elt.t -> 'a t -> 'a option
+  end)
 = struct
-    module type S =
-      sig
-        type t
-        type elt
-        module Class : sig
-          type t
-          val compare : t -> t -> int
-        end
-        val find : elt -> t -> Class.t
-        val union : Class.t -> Class.t -> t -> t
-        val cardinal : Class.t -> t -> int
-      end
+  type node = Leaf of int | Link of Elt.t
+  type elt = Elt.t
+  type t = node EMap.t ref
 
-    module Core
-      (Elt : sig
-        type t
-        val compare : t -> t -> int
-      end)
-      (EMap : sig
-        type 'a t
-        val add : Elt.t -> 'a -> 'a t -> 'a t
-        val find_opt : Elt.t -> 'a t -> 'a option
-      end)
-    = struct
-      type node = Leaf of int | Link of Elt.t
-      type elt = Elt.t
-      type t = node EMap.t ref
+  module Class = Elt
 
-      module Class = Elt
+  let cardinal x uf =
+    match EMap.find_opt x !uf with
+    | None -> 1
+    | Some (Leaf x) -> x
+    | Some (Link _) -> raise (Invalid_argument "cardinal")
 
-      let cardinal x uf =
-        match EMap.find_opt x !uf with
-        | None -> 1
-        | Some (Leaf x) -> x
-        | Some (Link _) -> raise (Invalid_argument "cardinal")
+  let rec find x uf =
+    match EMap.find_opt x !uf with
+    | None | Some (Leaf _) -> x
+    | Some (Link y) ->
+        let z = find y uf in
+        uf := EMap.add x (Link z) !uf; z
 
-      let rec find x uf =
-        match EMap.find_opt x !uf with
-        | None | Some (Leaf _) -> x
-        | Some (Link y) ->
-            let z = find y uf in
-            uf := EMap.add x (Link z) !uf; z
-
-      let union x y uf =
-        if Class.compare x y = 0
-        then uf
-        else begin
-          let x, y = 
-            if cardinal x uf <= cardinal y uf then x, y else y, x in
-          ref @@
-          EMap.add y (Link x) @@
-          EMap.add x (Leaf (cardinal x uf + cardinal y uf)) !uf
-        end
+  let union x y uf =
+    if Class.compare x y = 0
+    then uf
+    else begin
+      let x, y = 
+        if cardinal x uf <= cardinal y uf then x, y else y, x in
+      ref @@
+      EMap.add y (Link x) @@
+      EMap.add x (Leaf (cardinal x uf + cardinal y uf)) !uf
     end
+end
 
-    module ByHashtbl = struct
-      module Make (Elt : Map.OrderedType) = struct
-        include (Core (Elt) (struct
-          type 'a t = (Elt.t, 'a) PHashtbl.t
-          let add x y h = PHashtbl.replace h x y
-          let find_opt x h = try Some (PHashtbl.find h x) with Not_found -> None
-        end))
+module ByHashtbl = struct
+  module Make (Elt : Map.OrderedType) = struct
+    include (Core (Elt) (struct
+      type 'a t = (Elt.t, 'a) PHashtbl.t
+      let add x y h = PHashtbl.replace h x y
+      let find_opt x h = try Some (PHashtbl.find h x) with Not_found -> None
+    end))
 
-        let make n = ref (PHashtbl.create n)
-      end
-    end
+    let make n = ref (PHashtbl.create n)
+  end
+end
 
-    module ByMap = struct
-      module Make (Elt : Map.OrderedType) = struct
-        module EMap = Map.Make (Elt)
-        include (Core (Elt) (EMap))
-        let make () = ref EMap.empty
-      end
-    end
+module ByMap = struct
+  module Make (Elt : Map.OrderedType) = struct
+    module EMap = Map.Make (Elt)
+    include (Core (Elt) (EMap))
+    let make () = ref EMap.empty
+  end
 end

--- a/lib/containers/pUnionFind.ml
+++ b/lib/containers/pUnionFind.ml
@@ -97,12 +97,12 @@ module PersistentUnionFind :
     module ByHashtbl = struct
       module Make (Elt : Map.OrderedType) = struct
         include (Core (Elt) (struct
-          type 'a t = (Elt.t, 'a) PHashtbl.PHashtbl.t
-          let add x y h = PHashtbl.PHashtbl.replace h x y
-          let find_opt x h = try Some (PHashtbl.PHashtbl.find h x) with Not_found -> None
+          type 'a t = (Elt.t, 'a) PHashtbl.t
+          let add x y h = PHashtbl.replace h x y
+          let find_opt x h = try Some (PHashtbl.find h x) with Not_found -> None
         end))
 
-        let make n = ref (PHashtbl.PHashtbl.create n)
+        let make n = ref (PHashtbl.create n)
       end
     end
 

--- a/lib/containers/pUnionFind.mli
+++ b/lib/containers/pUnionFind.mli
@@ -1,0 +1,37 @@
+module type S = sig
+  type t
+  type elt
+  module Class : sig
+    (* 集合の識別子 *)
+    type t
+    val compare : t -> t -> int
+  end
+  (* 要素がどの集合に属するか調べる *)
+  val find : elt -> t -> Class.t
+  (* 与えられた集合同士を合併する *)
+  val union : Class.t -> Class.t -> t -> t
+  (* 与えられた集合に属する要素の数を求める *)
+  val cardinal : Class.t -> t -> int
+end
+
+(* 永続ハッシュテーブルを用いた実装 *)
+module ByHashtbl : sig
+  module Make :
+    functor (Elt : Map.OrderedType) ->
+    sig
+      include S
+      (* n要素が異なる集合に属した素集合データ構造を作成 *)
+      val make : int -> t
+    end with type elt = Elt.t
+end
+
+(* Mapを用いた実装 *)
+module ByMap : sig
+  module Make :
+    functor (Elt : Map.OrderedType) ->
+    sig
+      include S
+      (* 全ての要素が異なる集合に属した素集合データ構造を作成 *)
+      val make : unit -> t
+    end with type elt = Elt.t
+end

--- a/lib/containers/unionFind.ml
+++ b/lib/containers/unionFind.ml
@@ -1,56 +1,45 @@
 (* 素集合データ構造 *)
-module UnionFind = struct
-  module Make (Set : sig
+module Make
+  (Set : sig
     type t
     val union : t -> t -> t
-  end) : sig
-    type t
-    (* 与えられた集合から素集合データ構造を作る *)
-    val make : Set.t -> t
-    (* 与えられた素集合同士が同一かどうか判定する *)
-    val equal : t -> t -> bool
-    (* 与えられた素集合同士を合併する *)
-    val unite : t -> t -> unit
-    (* 与えられた素集合に属する要素を列挙する *)
-    val elements : t -> Set.t
-  end = struct
-    type t = node ref
-    and node =
-      | Root of int * Set.t (* 木の高さと要素の集合の二つ組 *)
-      | Link of t
+  end)
+= struct
+  type t = node ref
+  and node =
+    | Root of int * Set.t (* 木の高さと要素の集合の二つ組 *)
+    | Link of t
 
-    let make s = ref @@ Root (0, s)
+  let make s = ref @@ Root (0, s)
 
-    let rec find uf =
-      match !uf with
-      | Root _ -> uf
-      | Link parent ->
-          let root = find parent in
-          uf := Link root; root
+  let rec find uf =
+    match !uf with
+    | Root _ -> uf
+    | Link parent ->
+        let root = find parent in
+        uf := Link root; root
 
-    let equal uf uf' = find uf == find uf'
+  let equal uf uf' = find uf == find uf'
 
-    let unite uf uf' =
-      let root = find uf in
-      let root' = find uf' in
-      if root != root' then begin
-        match !root, !root' with
-        | Link _, _
-        | _, Link _ -> failwith "unite"
-        | Root (rank, elts), Root (rank', elts') ->
-            let root, root' =
-              if rank <= rank'
-              then root, root'
-              else root', root in
-            root := Link root';
-            root' := Root (rank' + (if rank = rank' then 1 else 0), Set.union elts elts')
-      end
+  let unite uf uf' =
+    let root = find uf in
+    let root' = find uf' in
+    if root != root' then begin
+      match !root, !root' with
+      | Link _, _
+      | _, Link _ -> failwith "unite"
+      | Root (rank, elts), Root (rank', elts') ->
+          let root, root' =
+            if rank <= rank'
+            then root, root'
+            else root', root in
+          root := Link root';
+          root' := Root (rank' + (if rank = rank' then 1 else 0), Set.union elts elts')
+    end
 
-    let elements uf =
-      match find uf with
-      | { contents = Link _ } -> failwith "elements"
-      | { contents = Root (_, elts) } -> elts
-  end
+  let elements uf =
+    match find uf with
+    | { contents = Link _ } -> failwith "elements"
+    | { contents = Root (_, elts) } -> elts
 end
-
 

--- a/lib/containers/unionFind.mli
+++ b/lib/containers/unionFind.mli
@@ -1,0 +1,15 @@
+module Make (Set : sig
+  type t
+  val union : t -> t -> t
+end)
+: sig
+  type t
+  (* 与えられた集合から素集合データ構造を作る *)
+  val make : Set.t -> t
+  (* 与えられた素集合同士が同一かどうか判定する *)
+  val equal : t -> t -> bool
+  (* 与えられた素集合同士を合併する *)
+  val unite : t -> t -> unit
+  (* 与えられた素集合に属する要素を列挙する *)
+  val elements : t -> Set.t
+end

--- a/lib/coordComp.ml
+++ b/lib/coordComp.ml
@@ -1,5 +1,5 @@
 (* 座標圧縮 *)
-module CoordComp
+module F
   (* 座標の型 *)
   (Coord : sig
     type t

--- a/lib/graph/bellmanFord.ml
+++ b/lib/graph/bellmanFord.ml
@@ -1,4 +1,4 @@
-module WeightedDirectedGraph
+module F
   (Weight : sig
     type t
     val inf : t (* オーバーフローの恐れはないので，max_intとか突っ込んでも良い *)
@@ -6,24 +6,8 @@ module WeightedDirectedGraph
     val neg_inf : t (* オーバーフローの恐れはないので，min_intとか突っ込んでも良い *)
     val ( + ) : t -> t -> t
     val compare : t -> t -> int
-  end) :
-sig
-  type 'a church_list = { fold : 'b. ('a -> 'b -> 'b) -> 'b -> 'b }
-
-  val bellman_ford :
-    (* 頂点数n *)
-    int ->
-    (* 辺のリスト
-       頂点は0からn-1までの整数でなくてはならない *)
-    (int * int * Weight.t) church_list ->
-    (* 始点 *)
-    int ->
-    (* 頂点を受け取り，そこまでの距離を返す関数
-       頂点に到達するパスが無ければinfを返し，
-       そこに到達するまでに負閉路があればneg_infを返す *)
-    (int -> Weight.t)
-end =
-struct
+  end)
+= struct
   type 'a church_list = { fold : 'b. ('a -> 'b -> 'b) -> 'b -> 'b }
 
   let bellman_ford n es s =

--- a/lib/graph/bellmanFord.mli
+++ b/lib/graph/bellmanFord.mli
@@ -1,0 +1,25 @@
+module F
+  (Weight : sig
+    type t
+    val inf : t (* オーバーフローの恐れはないので，max_intとか突っ込んでも良い *)
+    val zero : t
+    val neg_inf : t (* オーバーフローの恐れはないので，min_intとか突っ込んでも良い *)
+    val ( + ) : t -> t -> t
+    val compare : t -> t -> int
+  end) :
+sig
+  type 'a church_list = { fold : 'b. ('a -> 'b -> 'b) -> 'b -> 'b }
+
+  val bellman_ford :
+    (* 頂点数n *)
+    int ->
+    (* 辺のリスト
+       頂点は0からn-1までの整数でなくてはならない *)
+    (int * int * Weight.t) church_list ->
+    (* 始点 *)
+    int ->
+    (* 頂点を受け取り，そこまでの距離を返す関数
+       頂点に到達するパスが無ければinfを返し，
+       そこに到達するまでに負閉路があればneg_infを返す *)
+    (int -> Weight.t)
+end

--- a/lib/graph/bfs.ml
+++ b/lib/graph/bfs.ml
@@ -1,4 +1,4 @@
-module DirectedGraph
+module F
   (* 頂点を添字，経路長を要素とした配列の実装 *)
   (Array : sig
     type t

--- a/lib/graph/bfs01.ml
+++ b/lib/graph/bfs01.ml
@@ -1,4 +1,4 @@
-module Weighted01DirectedGraph
+module F
   (* 頂点を添字，経路長を要素とした配列の実装 *)
   (Array : sig
     type t

--- a/lib/graph/dijkstra.ml
+++ b/lib/graph/dijkstra.ml
@@ -1,4 +1,4 @@
-module WeightedDirectedGraph
+module F
   (* 辺の重み *)
   (Weight : sig
     type t

--- a/lib/graph/dinic.ml
+++ b/lib/graph/dinic.ml
@@ -27,7 +27,7 @@ sig
     (int * int * Flow.t) church_list
 end =
 struct
-  module G = Bfs.DirectedGraph (struct
+  module G = Bfs.F (struct
     type t = int array
     type key = int
     type elt = int

--- a/lib/graph/dinic.ml
+++ b/lib/graph/dinic.ml
@@ -1,4 +1,4 @@
-module FlowNetwork
+module F
   (* 流量 *)
   (Flow : sig
     type t

--- a/lib/graph/kruskal.ml
+++ b/lib/graph/kruskal.ml
@@ -1,4 +1,4 @@
-module WeightedGraph
+module F
   (Weight : sig
     type t
     val compare : t -> t -> int

--- a/lib/graph/kruskal.ml
+++ b/lib/graph/kruskal.ml
@@ -26,7 +26,7 @@ sig
     (int * int * Weight.t) church_list
 end =
 struct
-  module UF = UnionFind.UnionFind.Make (struct
+  module UF = UnionFind.Make (struct
     type t = unit
     let union _ _ = ()
   end)

--- a/lib/graph/prim.ml
+++ b/lib/graph/prim.ml
@@ -1,4 +1,4 @@
-module WeightedGraph
+module F
   (* 辺の重み *)
   (Weight : sig
     type t

--- a/lib/graph/scc.ml
+++ b/lib/graph/scc.ml
@@ -1,4 +1,4 @@
-module DirectedGraph (VSet : Set.S) :
+module F (VSet : Set.S) :
 sig
   (* トポロジカルソート *)
   val sort :

--- a/lib/graph/warshallFloyd.ml
+++ b/lib/graph/warshallFloyd.ml
@@ -1,4 +1,4 @@
-module WeightedDirectedGraph
+module F
   (Weight : sig
     type t
     val inf : t (* オーバーフローの恐れはないので，max_intとか突っ込んでも良い *)

--- a/lib/lis.ml
+++ b/lib/lis.ml
@@ -1,4 +1,4 @@
-module Lis (ESet : Set.S) = struct
+module F (ESet : Set.S) = struct
   let lis as_ = ESet.cardinal @@ List.fold_left (fun l a ->
     match ESet.split a l with
     | _, true, _ -> l

--- a/lib/misc.ml
+++ b/lib/misc.ml
@@ -43,3 +43,8 @@ let call_cc f =
   let return = ref (fun () -> raise Not_found) in
   try f (fun x -> (return := fun () -> x); raise Exodus)
   with Exodus -> !return ()
+
+(* compute exponentiation *)
+let rec power ( * ) e m n =
+  if n <= 0 then e
+  else power ( * ) (if n land 1 = 0 then e else m * e) (m * m) (n lsr 1);;

--- a/lib/power.ml
+++ b/lib/power.ml
@@ -1,4 +1,0 @@
-(* compute exponentiation *)
-let rec power ( * ) e m n =
-  if n <= 0 then e
-  else power ( * ) (if n land 1 = 0 then e else m * e) (m * m) (n lsr 1);;

--- a/lib/regexp.ml
+++ b/lib/regexp.ml
@@ -1,99 +1,66 @@
-module RegExp : sig
-  type t
-  val empty_set : t
-  val empty_str : t
-  val char : Char.t -> t
-  val app : t -> t -> t
-  val neg : t -> t
-  val inter : t -> t -> t
-  val union : t -> t -> t
-  val star : t -> t
+type t =
+  { sort : sort;
+    is_nullable : bool;
+    derive : char -> t }
+and sort =
+  | EmptySet
+  | EmptyStr
+  | Other
 
-  val matches : t -> Char.t list -> bool
-end = struct
-  type t =
-    { sort : sort;
-      is_nullable : bool;
-      derive : char -> t }
-  and sort =
-    | EmptySet
-    | EmptyStr
-    | Other
+let rec empty_set =
+  { sort = EmptySet;
+    is_nullable = false;
+    derive = fun _ -> empty_set }
 
-  let rec empty_set =
-    { sort = EmptySet;
-      is_nullable = false;
-      derive = fun _ -> empty_set }
+let empty_str =
+  { sort = EmptyStr;
+    is_nullable = true;
+    derive = fun _ -> empty_set }
 
-  let empty_str =
-    { sort = EmptyStr;
-      is_nullable = true;
-      derive = fun _ -> empty_set }
+let char c =
+  { sort = Other;
+    is_nullable = false;
+    derive = fun c' -> if c = c' then empty_str else empty_set }
 
-  let char c =
-    { sort = Other;
-      is_nullable = false;
-      derive = fun c' -> if c = c' then empty_str else empty_set }
+let rec neg re =
+  { sort = Other;
+    is_nullable = not re.is_nullable;
+    derive = fun c -> neg (re.derive c) }
 
-  let rec neg re =
-    { sort = Other;
-      is_nullable = not re.is_nullable;
-      derive = fun c -> neg (re.derive c) }
+let rec inter re1 re2 =
+  { sort = Other;
+    is_nullable = re1.is_nullable && re2.is_nullable;
+    derive = fun c -> inter (re1.derive c) (re2.derive c) }
 
-  let rec inter re1 re2 =
-    { sort = Other;
-      is_nullable = re1.is_nullable && re2.is_nullable;
-      derive = fun c -> inter (re1.derive c) (re2.derive c) }
+let rec union re1 re2 =
+  match re1, re2 with
+  | { sort = EmptySet; _ }, _ -> re2
+  | _, { sort = EmptySet; _ } -> re1
+  | _, _ ->
+      { sort = Other;
+        is_nullable = re1.is_nullable || re2.is_nullable;
+        derive = fun c -> union (re1.derive c) (re2.derive c) }
 
-  let rec union re1 re2 =
-    match re1, re2 with
-    | { sort = EmptySet; _ }, _ -> re2
-    | _, { sort = EmptySet; _ } -> re1
-    | _, _ ->
+let rec app re1 re2 =
+  match re1, re2 with
+  | { sort = EmptyStr; _ }, _ -> re2
+  | { sort = EmptySet; _ }, _ -> empty_set
+  | _, _ ->
+      { sort = Other;
+        is_nullable = re1.is_nullable && re2.is_nullable;
+        derive = fun c ->
+          union
+            (app (re1.derive c) re2)
+            (if re1.is_nullable then re2.derive c else empty_set) }
+
+let star = function
+  | { sort = EmptySet; _ }
+  | { sort = EmptyStr; _ } -> empty_str
+  | re0 ->
+      let rec re =
         { sort = Other;
-          is_nullable = re1.is_nullable || re2.is_nullable;
-          derive = fun c -> union (re1.derive c) (re2.derive c) }
+          is_nullable = true;
+          derive = fun c -> app (re0.derive c) re } in re
 
-  let rec app re1 re2 =
-    match re1, re2 with
-    | { sort = EmptyStr; _ }, _ -> re2
-    | { sort = EmptySet; _ }, _ -> empty_set
-    | _, _ ->
-        { sort = Other;
-          is_nullable = re1.is_nullable && re2.is_nullable;
-          derive = fun c ->
-            union
-              (app (re1.derive c) re2)
-              (if re1.is_nullable then re2.derive c else empty_set) }
-
-  let star = function
-    | { sort = EmptySet; _ }
-    | { sort = EmptyStr; _ } -> empty_str
-    | re0 ->
-        let rec re =
-          { sort = Other;
-            is_nullable = true;
-            derive = fun c -> app (re0.derive c) re } in re
-
-  let matches re s =
-    (List.fold_left (fun re -> re.derive) re s).is_nullable
-end
-
-(*
-let () =
-  let s = read_line () in
-  print_endline @@
-  if
-    let open RegExp in
-    matches
-      (* ((dream(er)?)|(erase(r)?))* *)
-      (star @@
-        union
-          (app (char 'd') @@ app (char 'r') @@ app (char 'e') @@ app (char 'a') @@ app (char 'm') @@
-            union empty_str @@ app (char 'e') @@ char 'r')
-          (app (char 'e') @@ app (char 'r') @@ app (char 'a') @@ app (char 's') @@ app (char 'e') @@
-            (union empty_str @@ char 'r'))) @@
-      Array.to_list @@ Array.init (String.length s) (String.get s)
-  then "YES"
-  else "NO"
-*)
+let matches re s =
+  (List.fold_left (fun re -> re.derive) re s).is_nullable

--- a/lib/regexp.mli
+++ b/lib/regexp.mli
@@ -1,0 +1,12 @@
+type t
+
+val empty_set : t
+val empty_str : t
+val char : Char.t -> t
+val app : t -> t -> t
+val neg : t -> t
+val inter : t -> t -> t
+val union : t -> t -> t
+val star : t -> t
+
+val matches : t -> Char.t list -> bool

--- a/test/binom.ml
+++ b/test/binom.ml
@@ -8,7 +8,7 @@ let%test "10C3 in int64 (memoized ver)" = let open Int64 in Compelib.Binom.binom
 (* クソデカ素数で割った余りを求めたいとき *)
 let m = 998244353
 let ( *^ ) x y = (x * y) mod m
-let ( /^ ) x y = Compelib.Power.power ( *^ ) x y (m - 2) (* フェルマーの小定理 *)
+let ( /^ ) x y = Compelib.Misc.power ( *^ ) x y (m - 2) (* フェルマーの小定理 *)
 
 let%test "4C2 mod prime" = Compelib.Binom.binom ~of_int:Fun.id ~mul:( *^ ) ~div:( /^ ) 4 2 = 6
 let%test "10C3 mod prime" = Compelib.Binom.binom ~of_int:Fun.id ~mul:( *^ ) ~div:( /^ ) 10 3 = 120

--- a/test/coordComp.ml
+++ b/test/coordComp.ml
@@ -1,4 +1,4 @@
-module CC = Compelib.CoordComp.CoordComp (struct
+module CC = Compelib.CoordComp.F (struct
   type t = int
   let compare = compare
 end)

--- a/test/graph/bellmanFord.ml
+++ b/test/graph/bellmanFord.ml
@@ -1,6 +1,6 @@
 (* sample code *)
 
-module G = Compelib.BellmanFord.WeightedDirectedGraph (struct
+module G = Compelib.BellmanFord.F (struct
   type t = int
   let zero = 0
   let inf = max_int

--- a/test/graph/bfs.ml
+++ b/test/graph/bfs.ml
@@ -1,4 +1,4 @@
-module G = Compelib.Bfs.DirectedGraph (struct
+module G = Compelib.Bfs.F (struct
   type t = (int, Bigarray.int_elt, Bigarray.c_layout) Bigarray.Genarray.t
   type elt = int
   type key = int array

--- a/test/graph/dijkstra.ml
+++ b/test/graph/dijkstra.ml
@@ -7,7 +7,7 @@ end
 
 module IntMap = Map.Make (Int)
 
-module G = Compelib.Dijkstra.WeightedDirectedGraph (Int)
+module G = Compelib.Dijkstra.F (Int)
   (struct
     type t = int list IntMap.t ref
     type elt = int
@@ -43,7 +43,7 @@ let%test _ =
   fun u f -> Fun.flip List.iter e.(u) @@ fun (v, c) -> f v @@ ( + ) c
 
 (* 経路長をMapに保存する *)
-module G' = Compelib.Dijkstra.WeightedDirectedGraph (Int)
+module G' = Compelib.Dijkstra.F (Int)
   (struct
     type t = int list IntMap.t ref
     type elt = int
@@ -90,7 +90,7 @@ end
 
 module WeightedRouteMap = Map.Make (WeightedRoute)
 
-module G'' = Compelib.Dijkstra.WeightedDirectedGraph (WeightedRoute)
+module G'' = Compelib.Dijkstra.F (WeightedRoute)
   (struct
     type t = int list WeightedRouteMap.t ref
     type elt = int

--- a/test/graph/dinic.ml
+++ b/test/graph/dinic.ml
@@ -1,5 +1,5 @@
 (* 蟻本p. 188のグラフで試す *)
-module G = Compelib.Dinic.FlowNetwork
+module G = Compelib.Dinic.F
 (struct
   type t = int
   let inf = max_int

--- a/test/graph/kruskal.ml
+++ b/test/graph/kruskal.ml
@@ -1,4 +1,4 @@
-module G = Compelib.Kruskal.WeightedGraph (struct
+module G = Compelib.Kruskal.F (struct
   type t = int
   let compare = compare
 end)

--- a/test/graph/prim.ml
+++ b/test/graph/prim.ml
@@ -9,7 +9,7 @@ end
 
 module IntMap = Map.Make (Int)
 
-module G = Compelib.Prim.WeightedGraph (Int)
+module G = Compelib.Prim.F (Int)
   (struct
     type t = int list IntMap.t ref
     type key = int
@@ -58,7 +58,7 @@ end
 
 module WeightedRouteMap = Map.Make (WeightedRoute)
 
-module G' = Compelib.Prim.WeightedGraph (WeightedRoute)
+module G' = Compelib.Prim.F (WeightedRoute)
   (struct
     type t = int list WeightedRouteMap.t ref
     type key = WeightedRoute.t

--- a/test/graph/scc.ml
+++ b/test/graph/scc.ml
@@ -1,7 +1,7 @@
 (* sample code *)
 
 module IntSet = Set.Make (Int)
-module IntG = Compelib.Scc.DirectedGraph (IntSet);;
+module IntG = Compelib.Scc.F (IntSet);;
 
 let%test _ =
   List.map (List.sort_uniq compare)

--- a/test/graph/warshallFloyd.ml
+++ b/test/graph/warshallFloyd.ml
@@ -7,7 +7,7 @@ module Int = struct
   let compare = compare
 end
 
-module G = Compelib.WarshallFloyd.WeightedDirectedGraph (Int)
+module G = Compelib.WarshallFloyd.F (Int)
 
 let d = G.warshall_floyd 5
   { G.fold = fun f -> List.fold_right f

--- a/test/lis.ml
+++ b/test/lis.ml
@@ -1,3 +1,3 @@
-module IntLis = Compelib.Lis.Lis (Set.Make (Int));;
+module IntLis = Compelib.Lis.F (Set.Make (Int));;
 
 let%test _ = IntLis.lis [4; 1; 6; 2; 8; 5; 7; 3] = 4

--- a/test/power.ml
+++ b/test/power.ml
@@ -1,10 +1,10 @@
 let%test _ =
   let n = 1000000000 in
-  Float.abs (Compelib.Power.power ( *. ) 1. (1. +. 1. /. float_of_int n) n -. 2.71828) <= 1e-5
+  Float.abs (Compelib.Misc.power ( *. ) 1. (1. +. 1. /. float_of_int n) n -. 2.71828) <= 1e-5
 
 let fib n =
   fst @@
-  Compelib.Power.power
+  Compelib.Misc.power
     (fun (fn1, fn_1) (fm1, fm_1) ->
       let fnfm = (fn1 - fn_1) * (fm1 - fm_1) in
       (fn1 * fm1 + fnfm, fnfm + fn_1 * fm_1)) (1, 1) (1, 0) n


### PR DESCRIPTION
https://github.com/fetburner/compelib/issues/13 の通り，名前空間が冗長（`UnionFind.UnionFind`とかある）だったのでリファクタリングした