### PR TITLE
Implement a cycle detection in the memoization combinator

### DIFF
--- a/lib/graph/pathReconstr.ml
+++ b/lib/graph/pathReconstr.ml
@@ -18,13 +18,21 @@ module F
     val join : t -> t -> t
     val snoc : t -> edge -> t
   end)
+  (Thunk : sig
+    type t
+    type elt = Path.t
+    val value : elt -> t
+    val running : t
+    val case : t -> value:(elt -> 'a) -> pending:(unit -> 'a) -> running:(unit -> 'a) -> 'a
+  end)
   (Array : sig
     type t
     type key = Edge.vertex
-    type elt = Path.t
+    type elt = Thunk.t
     type size
+
     val make : size -> t
-    val get : t -> key -> elt option
+    val get : t -> key -> elt
     val set : t -> key -> elt -> unit
   end)
 = struct
@@ -34,18 +42,24 @@ module F
   type vertex = Edge.vertex
   type vertices = Array.size
 
+  exception ZeroCycle
+
+  (* 実装としては完全にメモ化再帰だが，
+     訪れた頂点が始点かどうかの判定を書きたくないので独自実装に走る *)
   let path_reconstruction n es s d =
     let ps = Array.make n in
-    Array.set ps s Path.nil;
+    Array.set ps s (Thunk.value Path.nil);
     let rec path v =
-      match Array.get ps v with
-      | Some p -> p
-      | None ->
+      Thunk.case (Array.get ps v)
+        ~value:Fun.id
+        ~running:(fun () -> raise ZeroCycle)
+        ~pending:(fun () ->
+          Array.set ps v Thunk.running;
           let p = ref Path.empty in
           es v (fun e ->
             let u = Edge.source e in
             if Weight.equal (d v) (Edge.add_weight e (d u)) then
               p := Path.join !p (Path.snoc (path u) e));
-          Array.set ps v !p; !p in
+          Array.set ps v (Thunk.value !p); !p) in
     path
 end

--- a/lib/graph/pathReconstr.mli
+++ b/lib/graph/pathReconstr.mli
@@ -25,17 +25,23 @@ module F
     (* 集合に含まれる全ての経路の後端に辺を追加する *)
     val snoc : t -> edge -> t
   end)
-  (* 頂点を添字，Path.t option を要素とした配列の実装 *)
+  (Thunk : sig
+    type t
+    type elt = Path.t
+    val value : elt -> t
+    val running : t
+    val case : t -> value:(elt -> 'a) -> pending:(unit -> 'a) -> running:(unit -> 'a) -> 'a
+  end)
+  (* 頂点を添字，Thunk.t を要素とした配列の実装 *)
   (Array : sig
     type t
     type key = Edge.vertex
-    type elt = Path.t
+    type elt = Thunk.t
     type size
 
-    (* 全ての頂点について None で初期化された配列を作る *)
+    (* 全ての頂点について Thunk.pending で初期化された配列を作る *)
     val make : size -> t
-    val get : t -> key -> elt option
-    (* set a i x : 配列 a の i 番目の要素を Some x で更新する *)
+    val get : t -> key -> elt
     val set : t -> key -> elt -> unit
   end)
 : sig
@@ -45,8 +51,10 @@ module F
   type vertex = Edge.vertex
   type vertices = Array.size
 
+  exception ZeroCycle
+
   (* 最短経路の復元を行う
-     0辺だけの閉路があると無限ループに陥るので注意 *)
+     0辺だけの閉路があると ZeroCycle を投げる *)
   val path_reconstruction :
     (* グラフに含まれる頂点の集合 *)
     vertices ->

--- a/lib/memo.ml
+++ b/lib/memo.ml
@@ -1,33 +1,46 @@
 module F
+  (Thunk : sig
+    type t
+    type elt
+    val value : elt -> t
+    val running : t
+    val case : t -> value:(elt -> 'a) -> pending:(unit -> 'a) -> running:(unit -> 'a) -> 'a
+  end)
   (Array : sig
     type t
     type key
-    type elt
+    type elt = Thunk.t
     type size
     val make : size -> t
-    val get : t -> key -> elt option
+    val get : t -> key -> elt
     val set : t -> key -> elt -> unit
   end)
 = struct
+  exception InfiniteLoop
+
   type dom = Array.key
-  type cod = Array.elt
+  type cod = Thunk.elt
   type size = Array.size
 
   let memoize n f =
     let dp = Array.make n in
     let rec get i =
-      match Array.get dp i with
-      | Some x -> x
-      | None ->
+      Thunk.case (Array.get dp i)
+        ~value:Fun.id
+        ~running:(fun () -> raise InfiniteLoop)
+        ~pending:(fun () ->
+          Array.set dp i Thunk.running;
           let x = f get i in
-          Array.set dp i x; x in get
+          Array.set dp i (Thunk.value x); x) in get
 
   let memoize_cps n f =
     let dp = Array.make n in
     let rec get i k =
-      match Array.get dp i with
-      | Some x -> k x
-      | None ->
+      Thunk.case (Array.get dp i)
+        ~value:k
+        ~running:(fun () -> raise InfiniteLoop)
+        ~pending:(fun () ->
+          Array.set dp i Thunk.running;
           f get i @@ fun x ->
-            Array.set dp i x; k x in get
+            Array.set dp i (Thunk.value x); k x) in get
 end

--- a/lib/memo.mli
+++ b/lib/memo.mli
@@ -1,18 +1,24 @@
 module F
+  (Thunk : sig
+    type t
+    type elt
+    val value : elt -> t
+    val running : t
+    val case : t -> value:(elt -> 'a) -> pending:(unit -> 'a) -> running:(unit -> 'a) -> 'a
+  end)
   (Array : sig
     type t
     type key
-    type elt
+    type elt = Thunk.t
     type size
-    (* None で初期化された配列を作成する *)
+    (* Thunk.pending で初期化された配列を作成する *)
     val make : size -> t
-    val get : t -> key -> elt option
-    (* set a i x : 配列 a の i 番目の要素を Some x で更新する *)
+    val get : t -> key -> elt
     val set : t -> key -> elt -> unit
   end)
 : sig
   type dom = Array.key
-  type cod = Array.elt
+  type cod = Thunk.elt
   type size = Array.size
 
   (* メモ化付き不動点コンビネータ *)

--- a/test/memo.ml
+++ b/test/memo.ml
@@ -1,31 +1,51 @@
-module M = Compelib.Memo.F (struct
-  type t = int array
-  type key = int
-  type elt = int
-  type size = int
-  let make = Fun.flip Array.make (-1)
-  let get a i =
-    let x = a.(i) in
-    if x < 0 then None else Some x
-  let set = Array.set
-end)
+module M = Compelib.Memo.F
+  (struct
+    type t = int
+    type elt = int
+    let value = Fun.id
+    let running = -2
+    let case n ~value ~pending ~running =
+      match n with
+      | -1 -> pending ()
+      | -2 -> running ()
+      | n -> value n
+  end)
+  (struct
+    type t = int array
+    type key = int
+    type elt = int
+    type size = int
+    let make = Fun.flip Array.make (-1)
+    let get = Array.get
+    let set = Array.set
+  end)
 
 let fib = M.memoize 10 @@ fun fib n ->
   if n <= 1 then n else fib (n - 1) + fib (n - 2)
 
 let%test _ = List.init 10 fib = [0; 1; 1; 2; 3; 5; 8; 13; 21; 34]
 
-module N = Compelib.Memo.F (struct
-  type t = int array array
-  type key = int * int
-  type elt = int
-  type size = int * int
-  let make (n, m) = Array.make_matrix n m (-1)
-  let get a (i, j) =
-    let x = a.(i).(j) in
-    if x < 0 then None else Some x
-  let set a (i, j) x = a.(i).(j) <- x
-end)
+module N = Compelib.Memo.F
+  (struct
+    type t = int
+    type elt = int
+    let value = Fun.id
+    let running = -2
+    let case n ~value ~pending ~running =
+      match n with
+      | -1 -> pending ()
+      | -2 -> running ()
+      | n -> value n
+  end)
+  (struct
+    type t = int array array
+    type key = int * int
+    type elt = int
+    type size = int * int
+    let make (n, m) = Array.make_matrix n m (-1)
+    let get a (i, j) = a.(i).(j)
+    let set a (i, j) x = a.(i).(j) <- x
+  end)
 
 let routes = N.memoize (5, 5) @@ fun routes (n, m) ->
   if n = 0 || m = 0


### PR DESCRIPTION
メモ化を行う不動点コンビネータ（と経路復元）に，無限ループを検出する機構を実装する．
実行時間的にもメモリ使用量的にも大して負担にならないので実装してしまう．