### PR TITLE
Lazy path reconstruction

### DIFF
--- a/lib/graph/pathReconstr.mli
+++ b/lib/graph/pathReconstr.mli
@@ -20,8 +20,11 @@ module F
     val nil : t
     (* 空集合 *)
     val empty : t
-    (* 和集合 *)
-    val join : t -> t -> t
+    (* 和集合
+       最短経路を一つだけ求めれば良い場合は
+       let join = Fun.const
+       とすればよい *)
+    val join : t -> (unit -> t) -> t
     (* 集合に含まれる全ての経路の後端に辺を追加する *)
     val snoc : t -> edge -> t
   end)
@@ -58,8 +61,8 @@ module F
   val path_reconstruction :
     (* グラフに含まれる頂点の集合 *)
     vertices ->
-    (* 最短経路を求めたいグラフの，ある頂点``に''伸びる辺に対してのイテレータ *)
-    (vertex -> (edge -> unit) -> unit) ->
+    (* 最短経路を求めたいグラフの，ある頂点``に''伸びる辺のストリーム *)
+    (vertex -> edge Seq.t) ->
     (* 始点 *)
     vertex ->
     (* ある頂点への始点からの最短距離を返す関数 *)

--- a/test/graph/pathReconstr.ml
+++ b/test/graph/pathReconstr.ml
@@ -63,7 +63,7 @@ module M = Compelib.PathReconstr.F (Int)
     type edge = int * int
     let nil = []
     let empty = []
-    let join _ p = p
+    let join = Fun.const
     let snoc p (v, _) = v :: p
   end)
   (struct
@@ -94,5 +94,5 @@ let%test _ =
       e'.(v) <- (u, w) :: e'.(v))) e;
   ( = ) [[]; [0]; [0]; [2; 0]; [5; 2; 0]; [2; 0]] @@
   List.init 6 @@
-  M.path_reconstruction 6 (fun v f -> List.iter f e.(v)) 0 d
+  M.path_reconstruction 6 (fun v -> List.to_seq e.(v)) 0 d
 


### PR DESCRIPTION
## Why

最短経路の数え上げに対応した経路復元を実装したのは良いが，OCamlは値呼びなので，
最短経路が1つだけ分かれば良い場合であっても内部的には全ての最短経路を計算してしまっている．

## What

`Path.join`の第二引数を`unit -> Path.t`型とし，隣接リストをストリームとして与えることで，
最短経路が1つだけ分かれば良い場合は1つだけしか計算しないようにする．