### PR TITLE
Rewrite the lazy segment tree

### DIFF
--- a/lib/container/lazySegtree.ml
+++ b/lib/container/lazySegtree.ml
@@ -1,66 +1,108 @@
-module type Monoid = sig
-  type t
-  val e : t
-  val op : t -> t -> t
-end
-
-module Make (S : Monoid) = struct
+module Make
+  (S : sig
+    type t
+    val op : t -> t -> t
+  end)
+  (F : sig
+    type t
+    type dom = S.t
+    type cod = S.t
+    val id : t
+    val comp : t -> t -> t
+    val apply : t -> dom -> cod
+  end)
+= struct
   type elt = S.t
-  (* sizeがセグ木の要素数，dataは要素すべてをモノイドの演算で畳み込んだもの *)
-  type t = { size : int; data : elt; body : body lazy_t }
-  and body = Leaf | Node of t * t
+  type map = F.t
+
+  (* data は要素すべてをモノイドの演算で畳み込んだもの
+     pending は適用されていない写像
+     mutable だけど遅延していた計算結果の保存にしか使わないこと *)
+  type node = { mutable data : elt; mutable pending : map; child : (node * node) option }
+  type t = { size : int; node : node }
 
   let make_node left right =
-    { size = left.size + right.size;
-      data = S.op left.data right.data;
-      body = lazy (Node (left, right)) }
+    { data = S.op left.data right.data;
+      pending = F.id;
+      child = Some (left, right) }
 
-  let rec make n = 
+  (* セグ木の要素をどのように左右に分配するか
+     正整数nについて lsize n + rsize n = n が成り立たなくてはならない *)
+  let lsize n = n lsr 1
+  let rsize n = (n + 1) lsr 1
+
+  let rec of_list l = function
+    | 1 -> { data = List.hd l; pending = F.id; child = None }, List.tl l
+    | n ->
+        let t1, l = of_list l (lsize n) in
+        let t2, l = of_list l (rsize n) in
+        make_node t1 t2, l
+  let of_list l =
+    let n = List.length l in
+    assert (0 < n);
+    { size = n; node = fst (of_list l n) }
+
+  let rec init i f = function
+    | 1 -> { data = f i; pending = F.id; child = None }
+    | n -> make_node (init i f (lsize n)) (init (i + lsize n) f (rsize n))
+  let init n f =
     assert (1 <= n);
-    { size = n;
-      data = S.e;
-      body = lazy
-        begin match n with
-        | 1 -> Leaf
-        | n -> Node (make (n / 2), make ((n + 1) / 2))
-        end }
+    { size = n; node = init 0 f n }
 
-  let rec update i f t =
+  let force t =
+    Option.iter (fun (t1, t2) ->
+      t1.pending <- F.comp t.pending t1.pending;
+      t2.pending <- F.comp t.pending t2.pending) t.child;
+    t.data <- F.apply t.pending t.data;
+    t.pending <- F.id
+
+  let rec update n i f t =
+    force t;
+    match t.child with
+    | None -> { t with data = f t.data }
+    | Some (left, right) ->
+        if i < lsize n
+        then make_node (update (lsize n) i f left) right
+        else make_node left (update (rsize n) (i - lsize n) f right)
+  let update i f t =
     assert (0 <= i && i < t.size);
-    match t with
-    | { body = lazy Leaf; _ } -> { t with data = f t.data }
-    | { body = lazy (Node (left, right)); _ } ->
-        if i < left.size then make_node (update i f left) right
-        else make_node left (update (i - left.size) f right)
+    { t with node = update t.size i f t.node }
 
-  let rec update_range l r f t =
+  let rec update_range n l r f t =
+    if l <= 0 && n <= r
+    then { t with pending = F.comp f t.pending }
+    else begin
+      force t;
+      match t.child with
+      | None -> failwith "update_range"
+      | Some (left, right) ->
+          if r <= lsize n
+          then make_node (update_range (lsize n) l r f left) right
+          else if lsize n <= l
+          then make_node left (update_range (rsize n) (l - lsize n) (r - lsize n) f right)
+          else make_node
+                 (update_range (lsize n) l (lsize n) f left)
+                 (update_range (rsize n) 0 (r - lsize n) f right)
+    end
+  let update_range l r f t =
     assert (0 <= l && l < r && r <= t.size);
-    match t with
-    | { body = lazy Leaf; _ } -> { t with data = f t.data }
-    | { body = lazy (Node (left, right)); _ } ->
-        if l <= 0 && t.size <= r then
-          { t with
-            data = f t.data;
-            body = lazy
-              (Node
-                (update_range 0 left.size f left,
-                 update_range 0 right.size f right)) }
-        else if r <= left.size then
-          make_node (update_range l r f left) right
-        else if left.size <= l then
-          make_node left (update_range (l - left.size) (r - left.size) f right)
-        else
-          make_node
-            (update_range l left.size f left)
-            (update_range 0 (r - left.size) f right)
+    { t with node = update_range t.size l r f t.node }
 
-  let rec query l r t =
+  let rec query n l r t =
+    if l <= 0 && n <= r
+    then t.data
+    else begin
+      force t;
+      match t.child with
+      | None -> failwith "query"
+      | Some (left, right) ->
+          if r <= lsize n
+          then query (lsize n) l r left
+          else if lsize n <= l
+          then query (rsize n) (l - lsize n) (r - lsize n) right
+          else S.op (query (lsize n) l (lsize n) left) (query (rsize n) 0 (r - lsize n) right)
+    end
+  let query l r t =
     assert (0 <= l && l < r && r <= t.size);
-    match t with
-    | { body = lazy Leaf; _ } -> t.data
-    | { body = lazy (Node (left, right)); _ } ->
-        if l <= 0 && t.size <= r then t.data
-        else if r <= left.size then query l r left
-        else if left.size <= l then query (l - left.size) (r - left.size) right
-        else S.op (query l left.size left) (query 0 (r - left.size) right)
+    query t.size l r t.node
 end

--- a/lib/container/lazySegtree.ml
+++ b/lib/container/lazySegtree.ml
@@ -15,16 +15,39 @@ module Make
   type elt = S.t
   type map = F.t
 
-  (* data は要素すべてをモノイドの演算で畳み込んだもの
-     pending は適用されていない写像
-     mutable だけど遅延していた計算結果の保存にしか使わないこと *)
-  type node = { mutable data : elt; mutable pending : map; child : (node * node) option }
-  type t = { size : int; node : node }
+  (* 遅延セグ木の遅延評価に関する処理を隠蔽するため、 *)
+  module Node
+  : sig
+    type t
+    val leaf : elt -> t
+    val make : t -> t -> t
+    val apply : map -> t -> t
+    val force : t -> (elt -> (t * t) option -> 'a) -> 'a
+  end
+  = struct
+    (* data は要素すべてをモノイドの演算で畳み込んだもの
+       pending は適用されていない写像
+       mutable だけど遅延していた計算結果の保存にしか使わないこと *)
+    type t = { mutable data : elt; mutable pending : map; child : (t * t) option }
 
-  let make_node left right =
-    { data = S.op left.data right.data;
-      pending = F.id;
-      child = Some (left, right) }
+    let leaf data = { data; pending = F.id; child = None }
+    let make left right =
+      { data = S.op left.data right.data;
+        pending = F.id;
+        child = Some (left, right) }
+
+    let apply f t = { t with pending = F.comp f t.pending }
+
+    let force t k =
+      Option.iter (fun (t1, t2) ->
+        t1.pending <- F.comp t.pending t1.pending;
+        t2.pending <- F.comp t.pending t2.pending) t.child;
+      t.data <- F.apply t.pending t.data;
+      t.pending <- F.id;
+      k t.data t.child
+  end
+
+  type t = { size : int; node : Node.t }
 
   (* セグ木の要素をどのように左右に分配するか
      正整数nについて lsize n + rsize n = n が成り立たなくてはならない *)
@@ -32,76 +55,62 @@ module Make
   let rsize n = (n + 1) lsr 1
 
   let rec of_list l = function
-    | 1 -> { data = List.hd l; pending = F.id; child = None }, List.tl l
+    | 1 -> Node.leaf (List.hd l), List.tl l
     | n ->
         let t1, l = of_list l (lsize n) in
         let t2, l = of_list l (rsize n) in
-        make_node t1 t2, l
+        Node.make t1 t2, l
   let of_list l =
     let n = List.length l in
     assert (0 < n);
     { size = n; node = fst (of_list l n) }
 
   let rec init i f = function
-    | 1 -> { data = f i; pending = F.id; child = None }
-    | n -> make_node (init i f (lsize n)) (init (i + lsize n) f (rsize n))
+    | 1 -> Node.leaf (f i)
+    | n -> Node.make (init i f (lsize n)) (init (i + lsize n) f (rsize n))
   let init n f =
     assert (1 <= n);
     { size = n; node = init 0 f n }
 
-  let force t =
-    Option.iter (fun (t1, t2) ->
-      t1.pending <- F.comp t.pending t1.pending;
-      t2.pending <- F.comp t.pending t2.pending) t.child;
-    t.data <- F.apply t.pending t.data;
-    t.pending <- F.id
-
   let rec update n i f t =
-    force t;
-    match t.child with
-    | None -> { t with data = f t.data }
-    | Some (left, right) ->
-        if i < lsize n
-        then make_node (update (lsize n) i f left) right
-        else make_node left (update (rsize n) (i - lsize n) f right)
+    Node.force t @@ fun data -> function
+      | None -> Node.leaf (f data)
+      | Some (left, right) ->
+          if i < lsize n
+          then Node.make (update (lsize n) i f left) right
+          else Node.make left (update (rsize n) (i - lsize n) f right)
   let update i f t =
     assert (0 <= i && i < t.size);
     { t with node = update t.size i f t.node }
 
   let rec update_range n l r f t =
     if l <= 0 && n <= r
-    then { t with pending = F.comp f t.pending }
-    else begin
-      force t;
-      match t.child with
+    then Node.apply f t
+    else Node.force t @@ fun _ -> function
       | None -> failwith "update_range"
       | Some (left, right) ->
           if r <= lsize n
-          then make_node (update_range (lsize n) l r f left) right
+          then Node.make (update_range (lsize n) l r f left) right
           else if lsize n <= l
-          then make_node left (update_range (rsize n) (l - lsize n) (r - lsize n) f right)
-          else make_node
+          then Node.make left (update_range (rsize n) (l - lsize n) (r - lsize n) f right)
+          else Node.make
                  (update_range (lsize n) l (lsize n) f left)
                  (update_range (rsize n) 0 (r - lsize n) f right)
-    end
   let update_range l r f t =
     assert (0 <= l && l < r && r <= t.size);
     { t with node = update_range t.size l r f t.node }
 
   let rec query n l r t =
-    if l <= 0 && n <= r
-    then t.data
-    else begin
-      force t;
-      match t.child with
-      | None -> failwith "query"
+    Node.force t @@ fun data -> function
+      | None -> data
       | Some (left, right) ->
-          if r <= lsize n
+          if l <= 0 && n <= r
+          then data
+          else if r <= lsize n
           then query (lsize n) l r left
           else if lsize n <= l
           then query (rsize n) (l - lsize n) (r - lsize n) right
           else S.op (query (lsize n) l (lsize n) left) (query (rsize n) 0 (r - lsize n) right)
-    end
   let query l r t =
     assert (0 <= l && l < r && r <= t.size);
     query t.size l r t.node

--- a/lib/container/lazySegtree.mli
+++ b/lib/container/lazySegtree.mli
@@ -1,27 +1,43 @@
-module type Monoid = sig
-  type t
-  val e : t
-  val op : t -> t -> t
-end
-
-module Make (S : Monoid) : sig
+module Make
+  (* 半群 *)
+  (S : sig
+    type t
+    val op : t -> t -> t
+  end)
+  (* 半群の自己同型写像 *)
+  (F : sig
+    type t
+    type dom = S.t
+    type cod = S.t
+    (* 恒等写像 *)
+    val id : t
+    (* 写像の合成 *)
+    val comp : t -> t -> t
+    (* 半群の要素に写像を適用する *)
+    val apply : t -> dom -> cod
+  end)
+: sig
   type t
   type elt = S.t
-  (* n要素の単位元からなるセグ木を作る *)
-  val make : int -> t
+  type map = F.t
+
+  (* 与えられたリストの要素からなる遅延セグ木を作る *)
+  val of_list : elt list -> t
+  (* f 0, ... f (n - 1)のn要素からなる遅延セグ木を作る *)
+  val init : int -> (int -> elt) -> t
   (* 
    * update i f t
-   * i番目の要素にfを適用したセグ木を作る
+   * i 番目の要素に f を適用したセグ木を作る
    *)
   val update : int -> (elt -> elt) -> t -> t
   (*
    * update_range l r f t
-   * [l, r)の要素に自己準同型写像fを適用したセグ木を作る
+   * [l, r) の要素に自己同型写像 f を適用したセグ木を作る
    *)
-  val update_range : int -> int -> (elt -> elt) -> t -> t
+  val update_range : int -> int -> map -> t -> t
   (*
    * query l r t
-   * [l, r)の要素の積を求める
+   * [l, r) の要素の積を求める
    *)
   val query : int -> int -> t -> elt
 end


### PR DESCRIPTION
## Why

現在 `'a Lazy.t` 型に基づいて遅延セグメント木を実装しているが、
この実装では区間更新クエリによって導入された写像同士を融合する術を持たないため、
配列を用いた一般的な遅延セグメント木に比べて償却計算量が悪化している問題があった。

## What

`'a Lazy.t` 型の代わりに書き換え可能なレコードを用いることで、
配列を用いた一般的な遅延セグメント木と同等の償却計算量の永続遅延セグメント木を実装する。