### PR TITLE
Use docker-coq for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,46 @@
-language: c
-sudo: required
-install: test -e .travis-opam.sh || wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-opam.sh
-script: bash -ex .travis-opam.sh
+dist: bionic
+language: generic
+
+services:
+  - docker
+
 env:
-  - OCAML_VERSION=4.10
-os:
-  - freebsd
-  - linux
-  - osx
+  global:
+  - PACKAGE_NAME="compelib"
+  matrix:
+  - COQ_IMAGE="coqorg/coq:8.10" SHOULD_SUPPORT="true"
+
+install: |
+  # Prepare the COQ container
+  docker pull ${COQ_IMAGE}
+  docker run -d -i --init --name=COQ -v ${TRAVIS_BUILD_DIR}:/home/project -w /home/project ${COQ_IMAGE}
+  docker exec COQ /bin/bash --login -c "
+    # This bash script is double-quoted to interpolate Travis CI env vars:
+    echo \"Build triggered by ${TRAVIS_EVENT_TYPE}\"
+    export PS4='+ \e[33;1m(\$0 @ line \$LINENO) \$\e[0m '
+    set -ex  # -e = exit on failure; -x = trace for debug
+    opam update
+    opam pin add ${PACKAGE_NAME} . --kind=path --no-action -y
+    opam config list; opam repo list; opam pin list; opam list
+    " install
+
+script:
+- echo -e "${ANSI_YELLOW}Building...${ANSI_RESET}" && echo -en 'travis_fold:start:script\\r'
+- |
+  docker exec COQ /bin/bash --login -c "
+    export PS4='+ \e[33;1m(\$0 @ line \$LINENO) \$\e[0m '
+    set -ex
+    sudo chown -R coq:coq /home/project
+    # Check if the package is compatible with the current environment
+    if [ "${SHOULD_SUPPORT}" = "true" ] || opam install ${PACKAGE_NAME} --show-action -y; then
+      # First install the dependencies
+      opam install ${PACKAGE_NAME} --deps-only -y
+      opam list
+      # Then install the package itself in verbose mode
+      opam install ${PACKAGE_NAME} -v -y
+    fi;
+    " script
+- echo -en 'travis_fold:end:script\\r'
+
+after_script:
+- docker stop COQ  # optional

--- a/compelib.opam
+++ b/compelib.opam
@@ -7,13 +7,12 @@ license: "MIT"
 homepage: "https://github.com/fetburner/compelib"
 bug-reports: "https://github.com/fetburner/compelib/issues"
 depends: [
-  "dune" {>= "2.7"}
+  "dune" {>= "2.5"}
   "coq" {>= "8.10"}
   "ppx_inline_test" {>= "0.14.1"}
-  "odoc" {with-doc}
 ]
 build: [
-  ["dune" "subst"] {dev}
+  ["dune" "subst"] {pinned}
   [
     "dune"
     "build"

--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 2.7)
+(lang dune 2.5)
 (using coq 0.2)
 
 (name compelib)


### PR DESCRIPTION
## Why

現状だと CI がマジで遅くて30分ぐらいかかったりするが，これは docker イメージを立ち上げてから毎回
OCaml やら Coq やらをソースコードからビルドしてインストールしているのが主な原因．
最初から OCaml とか Coq とかが入った docker イメージを使えば速くなる余地がある．

## What

[docker-coq](https://github.com/coq-community/docker-coq) とかいうのが OCaml とか Coq の入った docker イメージを公開しているので，それを使う．