### PR TITLE
Modify the interface of Graph algorithms

### DIFF
--- a/lib/graph/bellmanFord.ml
+++ b/lib/graph/bellmanFord.ml
@@ -1,47 +1,67 @@
-module F
-  (Vertex : sig
+module type WeightedDirectedGraph = sig
+  module Vertex : sig
     type t
+    type set
+    val universe : set
+    val cardinal_universe : int
     val compare : t -> t -> int
-  end)
-  (Weight : sig
+  end
+  module Distance : sig
     type t
-    val inf : t (* オーバーフローの恐れはないので，max_intとか突っ込んでも良い *)
+    val inf : t
     val zero : t
-    val neg_inf : t (* オーバーフローの恐れはないので，min_intとか突っ込んでも良い *)
+    val neg_inf : t
     val compare : t -> t -> int
-  end)
+  end
+  module Edge : sig
+    type t
+    val universe : t list
+    val source : t -> Vertex.t
+    val destination : t -> Vertex.t
+    val add_weight : t -> Distance.t -> Distance.t
+  end
+end
+
+module F
   (Array : sig
     type t
-    type key = Vertex.t
-    type elt = Weight.t
+    type key
+    type elt
     type size
     val make : size -> t
     val get : t -> key -> elt
     val set : t -> key -> elt -> unit
-    val size_to_int : size -> int
   end)
 = struct
-  type vertex = Vertex.t
-  type weight = Weight.t
+  type vertex = Array.key
+  type distance = Array.elt
   type vertices = Array.size
 
-  let shortest_path n es s =
-    let es = List.sort (fun (u, v, _) (u', v', _) ->
-      match Vertex.compare u v, Vertex.compare u' v' with
+  let shortest_path
+    (module G : WeightedDirectedGraph
+      with type Vertex.t = vertex
+       and type Vertex.set = vertices
+       and type Distance.t = distance) s =
+    let es = List.sort (fun e e' ->
+      let u = G.Edge.source e in
+      let v = G.Edge.destination e in
+      let u' = G.Edge.source e' in
+      let v' = G.Edge.destination e' in
+      match G.Vertex.compare u v, G.Vertex.compare u' v' with
       (* 自己辺同士は始点の小さい順に緩和 *)
-      | 0, 0 -> Vertex.compare u u'
+      | 0, 0 -> G.Vertex.compare u u'
       (* 添字の小さい頂点から大きい頂点への辺同士は，始点の小さい順に緩和 *)
-      | x, y when x < 0 && y < 0 -> Vertex.compare u u'
+      | x, y when x < 0 && y < 0 -> G.Vertex.compare u u'
       (* 添字の大きい頂点から小さい頂点への辺同士は，始点の大きい順に緩和 *)
-      | x, y when x > 0 && y > 0 -> Vertex.compare u' u
+      | x, y when x > 0 && y > 0 -> G.Vertex.compare u' u
       (* 自己辺は添字の小さい頂点から大きい頂点への辺と一緒のタイミングで緩和する *)
       | 0, y when y < 0 ->
-          begin match Vertex.compare u u' with
+          begin match G.Vertex.compare u u' with
           | 0 -> -1
           | x -> x
           end
       | x, 0 when x < 0 ->
-          begin match Vertex.compare u u' with
+          begin match G.Vertex.compare u u' with
           | 0 -> 1
           | x -> x
           end
@@ -51,26 +71,29 @@ module F
       | x, y when x > 0 && y < 0 -> 1
       | 0, y when y > 0 -> -1
       | x, 0 when x > 0 -> 1
-      | _, _ -> failwith "bellman_ford") es in
+      | _, _ -> failwith "bellman_ford") G.Edge.universe in
     (* 距離を覚えるやつ *)
-    let d = Array.make n in
-    Array.set d s Weight.zero;
+    let d = Array.make G.Vertex.universe in
+    Array.set d s G.Distance.zero;
     (* 残りの反復回数 *)
-    let i = ref (Array.size_to_int n) in
+    let i = ref G.Vertex.cardinal_universe in
     (* 負閉路とみなす閾値 *)
-    let th = succ (Array.size_to_int n) lsr 1 in
+    let th = succ G.Vertex.cardinal_universe lsr 1 in
     (* 更新が行われたか *)
     let is_modified = ref true in
     while 0 < !i && !is_modified do
       is_modified := false;
-      List.iter (fun (u, v, c) ->
-        let open Weight in
+      List.iter (fun e ->
         (* 原点から到達できない頂点は更新しない *)
-        let du = Array.get d u in
-        if 0 < Weight.compare inf du then
-          let dv = if 0 <= Weight.compare neg_inf du then neg_inf else c du in
-          if 0 < Weight.compare (Array.get d v) dv then
-            (is_modified := true; Array.set d v @@ if !i <= th then neg_inf else dv)) es;
+        let du = Array.get d (G.Edge.source e) in
+        if 0 < G.Distance.compare G.Distance.inf du then
+          let v = G.Edge.destination e in
+          let dv =
+            if 0 <= G.Distance.compare G.Distance.neg_inf du
+            then G.Distance.neg_inf
+            else G.Edge.add_weight e du in
+          if 0 < G.Distance.compare (Array.get d v) dv then
+            (is_modified := true; Array.set d v @@ if !i <= th then G.Distance.neg_inf else dv)) es;
         decr i
     done;
     Array.get d

--- a/lib/graph/bellmanFord.mli
+++ b/lib/graph/bellmanFord.mli
@@ -1,44 +1,54 @@
-module F
-  (Vertex : sig
+module type WeightedDirectedGraph = sig
+  module Vertex : sig
     type t
+    type set
+    val universe : set (* 頂点の全体集合 *)
+    val cardinal_universe : int (* 頂点数 *)
     val compare : t -> t -> int
-  end)
-  (Weight : sig
+  end
+  module Distance : sig
     type t
     val inf : t (* オーバーフローの恐れはないので，max_intとか突っ込んでも良い *)
     val zero : t
-    val neg_inf : t (* オーバーフローの恐れはないので，min_intとか突っ込んでも良い *)
-    val ( + ) : t -> t -> t
+    val neg_inf : t  (* オーバーフローの恐れはないので，min_intとか突っ込んでも良い *)
     val compare : t -> t -> int
-  end)
+  end
+  module Edge : sig
+    type t
+    val universe : t list (* グラフに含まれる辺のリスト *)
+    val source : t -> Vertex.t
+    val destination : t -> Vertex.t
+    (* 辺を通った際のコストを加算する関数 *)
+    val add_weight : t -> Distance.t -> Distance.t
+  end
+end
+
+module F
   (* 頂点を添字，経路長を要素とした配列の実装 *)
   (Array : sig
     type t
-    type key = Vertex.t
-    type elt = Weight.t
+    type key
+    type elt
     type size
-    (* Weight.inf で初期化された配列を作る *)
+    (* 無限大 で初期化された配列を作る *)
     val make : size -> t
     val get : t -> key -> elt
     val set : t -> key -> elt -> unit
-    val size_to_int : size -> int
   end) :
 sig
-  type vertex = Vertex.t
-  type weight = Weight.t
+  type vertex = Array.key
+  type distance = Array.elt
   type vertices = Array.size
 
   val shortest_path :
-    (* 頂点数n *)
-    vertices ->
-    (* 辺のリスト
-       緩和のスケジューリングのためにデータ構造が固定されている
-       重さは辺を通った際のコストを加算する関数として与える *)
-    ((vertex * vertex * (Weight.t -> Weight.t)) list) ->
+    (module WeightedDirectedGraph
+      with type Vertex.t = vertex
+       and type Vertex.set = vertices
+       and type Distance.t = distance) ->
     (* 始点 *)
     vertex ->
     (* 頂点を受け取り，そこまでの距離を返す関数
-       頂点に到達するパスが無ければinfを返し，
-       そこに到達するまでに負閉路があればneg_infを返す *)
-    (vertex -> Weight.t)
+       頂点に到達するパスが無ければ inf を返し，
+       そこに到達するまでに負閉路があれば neg_inf を返す *)
+    (vertex -> distance)
 end

--- a/lib/graph/bfs.ml
+++ b/lib/graph/bfs.ml
@@ -1,3 +1,12 @@
+module type DirectedGraph = sig
+  module Vertex : sig
+    type t
+    type set
+    val universe : set
+    val iter_adjacency : t -> (t -> unit) -> unit
+  end
+end
+
 module F
   (Array : sig
     type t
@@ -9,11 +18,15 @@ module F
     val set : t -> key -> elt -> unit
   end)
 = struct
+  type distance = int
   type vertex = Array.key
   type vertices = Array.size
 
-  let shortest_path n es s =
-    let d = Array.make n in
+  let shortest_path
+    (module G : DirectedGraph
+      with type Vertex.t = vertex
+       and type Vertex.set = vertices) s =
+    let d = Array.make G.Vertex.universe in
     (* 始点への経路長を0にする *)
     Array.set d s 0;
     let w = ref 1 in
@@ -30,7 +43,7 @@ module F
           | _ ->
               q := [];
               List.iter (fun u ->
-                es u @@ fun v ->
+                G.Vertex.iter_adjacency u @@ fun v ->
                   if !w < Array.get d v then
                     (q := v :: !q; Array.set d v !w)) us;
               incr w;

--- a/lib/graph/bfs.ml
+++ b/lib/graph/bfs.ml
@@ -3,7 +3,7 @@ module type DirectedGraph = sig
     type t
     type set
     val universe : set
-    val iter_adjacency : t -> (t -> unit) -> unit
+    val iter_adjacencies : t -> (t -> unit) -> unit
   end
 end
 
@@ -43,7 +43,7 @@ module F
           | _ ->
               q := [];
               List.iter (fun u ->
-                G.Vertex.iter_adjacency u @@ fun v ->
+                G.Vertex.iter_adjacencies u @@ fun v ->
                   if !w < Array.get d v then
                     (q := v :: !q; Array.set d v !w)) us;
               incr w;

--- a/lib/graph/bfs.mli
+++ b/lib/graph/bfs.mli
@@ -5,7 +5,7 @@ module type DirectedGraph = sig
     (* グラフに含まれる頂点の集合 *)
     val universe : set
     (* 最短経路を求めたいグラフの，ある頂点から伸びる辺に対してのイテレータ *)
-    val iter_adjacency : t -> (t -> unit) -> unit
+    val iter_adjacencies : t -> (t -> unit) -> unit
   end
 end
 

--- a/lib/graph/bfs.mli
+++ b/lib/graph/bfs.mli
@@ -1,28 +1,39 @@
+module type DirectedGraph = sig
+  module Vertex : sig
+    type t
+    type set
+    (* グラフに含まれる頂点の集合 *)
+    val universe : set
+    (* 最短経路を求めたいグラフの，ある頂点から伸びる辺に対してのイテレータ *)
+    val iter_adjacency : t -> (t -> unit) -> unit
+  end
+end
+
 module F
   (* 頂点を添字，経路長を要素とした配列の実装 *)
   (Array : sig
     type t
     type key
-    type elt = int (* 重みのない（=全ての重さが1な）グラフなので経路長は非負整数 *)
+    type elt = int (* 重みのない（= 全ての重さが1な）グラフなので経路長は非負整数 *)
     type size (* 頂点数 *)
     val make : size -> t (* 全ての頂点についての経路長が無限大で初期化された配列を作る *)
     val get : t -> key -> elt
     val set : t -> key -> elt -> unit
   end)
 : sig
+  type distance = int
   type vertex = Array.key
   type vertices = Array.size
 
   (* BFSにより，重みのないグラフの最短経路長を求める *)
   val shortest_path :
-    (* 頂点数 *)
-    vertices ->
-    (* 最短経路を求めたいグラフの，ある頂点から伸びる辺に対してのイテレータ *)
-    (vertex -> (vertex -> unit) -> unit) ->
+    (module DirectedGraph
+      with type Vertex.t = vertex
+       and type Vertex.set = vertices) ->
     (* 始点 *)
     vertex ->
     (* 終点を受け取って，始点からの最短距離を返す関数
        始点から辿り着けない場合，無限大を返す
        この関数を覚えておけば，呼び出しごとの途中までの計算結果がシェアされる *)
-    (vertex -> int)
+    (vertex -> distance)
 end

--- a/lib/graph/bfs01.ml
+++ b/lib/graph/bfs01.ml
@@ -3,7 +3,7 @@ module type Weighted01DirectedGraph = sig
     type t
     type set
     val universe : set
-    val iter_adjacency : t -> f0:(t -> unit) -> f1:(t -> unit) -> unit
+    val iter_adjacencies : t -> f0:(t -> unit) -> f1:(t -> unit) -> unit
   end
 end
 
@@ -46,7 +46,7 @@ module F
               incr w;
               bfs t
     and dfs u =
-      G.Vertex.iter_adjacency u
+      G.Vertex.iter_adjacencies u
         ~f0:(fun v ->
           if !w <= Array.get d v then
             (Array.set d v (!w - 1); dfs v))

--- a/lib/graph/bfs01.ml
+++ b/lib/graph/bfs01.ml
@@ -1,3 +1,12 @@
+module type Weighted01DirectedGraph = sig
+  module Vertex : sig
+    type t
+    type set
+    val universe : set
+    val iter_adjacency : t -> f0:(t -> unit) -> f1:(t -> unit) -> unit
+  end
+end
+
 module F
   (Array : sig
     type t
@@ -9,11 +18,15 @@ module F
     val set : t -> key -> elt -> unit
   end)
 = struct
+  type distance = int
   type vertex = Array.key
   type vertices = Array.size
 
-  let shortest_path n es s =
-    let d = Array.make n in
+  let shortest_path
+    (module G : Weighted01DirectedGraph
+      with type Vertex.t = vertex
+       and type Vertex.set = vertices) s =
+    let d = Array.make G.Vertex.universe in
     (* 始点への経路長を0にする *)
     Array.set d s 0;
     let w = ref 1 in
@@ -33,7 +46,7 @@ module F
               incr w;
               bfs t
     and dfs u =
-      es u
+      G.Vertex.iter_adjacency u
         ~f0:(fun v ->
           if !w <= Array.get d v then
             (Array.set d v (!w - 1); dfs v))

--- a/lib/graph/bfs01.mli
+++ b/lib/graph/bfs01.mli
@@ -7,7 +7,7 @@ module type Weighted01DirectedGraph = sig
     val universe : set
     (* 最短経路を求めたいグラフの，ある頂点から伸びる辺に対してのイテレータ
        重みが0の辺に対してはf0を，1の辺に対してはf1を用いる *)
-    val iter_adjacency : t -> f0:(t -> unit) -> f1:(t -> unit) -> unit
+    val iter_adjacencies : t -> f0:(t -> unit) -> f1:(t -> unit) -> unit
   end
 end
 

--- a/lib/graph/bfs01.mli
+++ b/lib/graph/bfs01.mli
@@ -1,3 +1,16 @@
+(* 0 または 1 で重み付けされた有向グラフ *)
+module type Weighted01DirectedGraph = sig
+  module Vertex : sig
+    type t
+    type set
+    (* グラフに含まれる頂点の集合 *)
+    val universe : set
+    (* 最短経路を求めたいグラフの，ある頂点から伸びる辺に対してのイテレータ
+       重みが0の辺に対してはf0を，1の辺に対してはf1を用いる *)
+    val iter_adjacency : t -> f0:(t -> unit) -> f1:(t -> unit) -> unit
+  end
+end
+
 module F
   (* 頂点を添字，経路長を要素とした配列の実装 *)
   (Array : sig
@@ -10,19 +23,18 @@ module F
     val set : t -> key -> elt -> unit
   end)
 : sig
+  type distance = int
   type vertex = Array.key
   type vertices = Array.size
 
   val shortest_path :
-    (* 頂点数 *)
-    vertices ->
-    (* 最短経路を求めたいグラフの，ある頂点から伸びる辺に対してのイテレータ
-       重みが0の辺に対してはf0を，1の辺に対してはf1を用いる *)
-    (vertex -> f0:(vertex -> unit) -> f1:(vertex -> unit) -> unit) ->
+    (module Weighted01DirectedGraph
+      with type Vertex.t = vertex
+       and type Vertex.set = vertices) ->
     (* 始点 *)
     vertex ->
     (* 終点を受け取って，始点からの最短距離を返す関数
        始点から辿り着けない場合，無限大を返す
        この関数を覚えておけば，呼び出しごとの途中までの計算結果がシェアされる *)
-    (vertex -> int)
+    (vertex -> distance)
 end

--- a/lib/graph/dijkstra.ml
+++ b/lib/graph/dijkstra.ml
@@ -8,7 +8,7 @@ module type WeightedDirectedGraph = sig
     type t
     type set
     val universe : set
-    val iter_adjacency : t -> (t -> (Distance.t -> Distance.t) -> unit) -> unit
+    val iter_adjacencies : t -> (t -> (Distance.t -> Distance.t) -> unit) -> unit
   end
 end
 
@@ -60,7 +60,7 @@ module F
           | _ ->
               (* 未だ頂点uを訪れていない *)
               if 0 <= G.Distance.compare (Array.get d u) w then
-                G.Vertex.iter_adjacency u (fun v f ->
+                G.Vertex.iter_adjacencies u (fun v f ->
                   (* uからvに伸びる辺を通った際の経路長 *)
                   let c = f w in
                   if 0 < G.Distance.compare (Array.get d v) c then

--- a/lib/graph/dijkstra.ml
+++ b/lib/graph/dijkstra.ml
@@ -1,5 +1,5 @@
 module type WeightedDirectedGraph = sig
-  module Weight : sig
+  module Distance : sig
     type t
     val zero : t
     val compare : t -> t -> int
@@ -8,7 +8,7 @@ module type WeightedDirectedGraph = sig
     type t
     type set
     val universe : set
-    val iter_adjacency : t -> (t -> (Weight.t -> Weight.t) -> unit) -> unit
+    val iter_adjacency : t -> (t -> (Distance.t -> Distance.t) -> unit) -> unit
   end
 end
 
@@ -32,18 +32,22 @@ module F
     val take_min_binding : t -> (key * elt) option
   end)
 = struct
+  type vertex = Array.key
+  type distance = Array.elt
+  type vertices = Array.size
+
   let shortest_path
     (module G : WeightedDirectedGraph
-      with type Weight.t = Array.elt
-       and type Vertex.t = Array.key
-       and type Vertex.set = Array.size) s =
+      with type Vertex.t = vertex
+       and type Vertex.set = vertices
+       and type Distance.t = distance) s =
     let q = Heap.make G.Vertex.universe in
     let d = Array.make G.Vertex.universe in
     (* 始点への経路長を0にする *)
-    Array.set d s G.Weight.zero;
+    Array.set d s G.Distance.zero;
     (* 既に最短距離が確定した辺へのクエリを高速化するため，
        ヒープの最小要素をメモしておく *)
-    let min_binding = ref @@ Some (G.Weight.zero, s) in
+    let min_binding = ref @@ Some (G.Distance.zero, s) in
     let rec dijkstra t =
       match !min_binding with
       (* もう既に全ての頂点までの距離が分かっている *)
@@ -51,15 +55,15 @@ module F
       | Some (w, u) ->
           match Array.get d t with
           (* 既に終点までの距離が分かっているので返す *)
-          | x when 0 <= G.Weight.compare w x -> x
+          | x when 0 <= G.Distance.compare w x -> x
           (* 終点までの距離が分かっていないので，ダイクストラ法を続行 *)
           | _ ->
               (* 未だ頂点uを訪れていない *)
-              if 0 <= G.Weight.compare (Array.get d u) w then
+              if 0 <= G.Distance.compare (Array.get d u) w then
                 G.Vertex.iter_adjacency u (fun v f ->
                   (* uからvに伸びる辺を通った際の経路長 *)
                   let c = f w in
-                  if 0 < G.Weight.compare (Array.get d v) c then
+                  if 0 < G.Distance.compare (Array.get d v) c then
                     (Heap.add q c v; Array.set d v c));
               min_binding := Heap.take_min_binding q;
               dijkstra t in

--- a/lib/graph/dijkstra.ml
+++ b/lib/graph/dijkstra.ml
@@ -1,40 +1,49 @@
-module F
-  (Weight : sig
+module type WeightedDirectedGraph = sig
+  module Weight : sig
     type t
     val zero : t
     val compare : t -> t -> int
-  end)
-  (Heap : sig
+  end
+  module Vertex : sig
     type t
-    type elt
-    type key = Weight.t
-    type size
-    val make : size -> t
-    val add : t -> key -> elt -> unit
-    val take_min_binding : t -> (key * elt) option
-  end)
+    type set
+    val universe : set
+    val iter_adjacency : t -> (t -> (Weight.t -> Weight.t) -> unit) -> unit
+  end
+end
+
+module F
   (Array : sig
     type t
-    type key = Heap.elt
-    type elt = Heap.key
-    type size = Heap.size
+    type key
+    type elt
+    type size
     val make : size -> t
     val get : t -> key -> elt
     val set : t -> key -> elt -> unit
   end)
+  (Heap : sig
+    type t
+    type elt = Array.key
+    type key = Array.elt
+    type size = Array.size
+    val make : size -> t
+    val add : t -> key -> elt -> unit
+    val take_min_binding : t -> (key * elt) option
+  end)
 = struct
-  type weight = Array.elt
-  type vertex = Array.key
-  type vertices = Array.size
-
-  let shortest_path n es s =
-    let q = Heap.make n in
-    let d = Array.make n in
+  let shortest_path
+    (module G : WeightedDirectedGraph
+      with type Weight.t = Array.elt
+       and type Vertex.t = Array.key
+       and type Vertex.set = Array.size) s =
+    let q = Heap.make G.Vertex.universe in
+    let d = Array.make G.Vertex.universe in
     (* 始点への経路長を0にする *)
-    Array.set d s Weight.zero;
+    Array.set d s G.Weight.zero;
     (* 既に最短距離が確定した辺へのクエリを高速化するため，
        ヒープの最小要素をメモしておく *)
-    let min_binding = ref (Some (Weight.zero, s)) in
+    let min_binding = ref @@ Some (G.Weight.zero, s) in
     let rec dijkstra t =
       match !min_binding with
       (* もう既に全ての頂点までの距離が分かっている *)
@@ -42,15 +51,15 @@ module F
       | Some (w, u) ->
           match Array.get d t with
           (* 既に終点までの距離が分かっているので返す *)
-          | x when 0 <= Weight.compare w x -> x
+          | x when 0 <= G.Weight.compare w x -> x
           (* 終点までの距離が分かっていないので，ダイクストラ法を続行 *)
           | _ ->
               (* 未だ頂点uを訪れていない *)
-              if 0 <= Weight.compare (Array.get d u) w then
-                es u (fun v f ->
+              if 0 <= G.Weight.compare (Array.get d u) w then
+                G.Vertex.iter_adjacency u (fun v f ->
                   (* uからvに伸びる辺を通った際の経路長 *)
                   let c = f w in
-                  if 0 < Weight.compare (Array.get d v) c then
+                  if 0 < G.Weight.compare (Array.get d v) c then
                     (Heap.add q c v; Array.set d v c));
               min_binding := Heap.take_min_binding q;
               dijkstra t in

--- a/lib/graph/dijkstra.mli
+++ b/lib/graph/dijkstra.mli
@@ -1,5 +1,5 @@
 module type WeightedDirectedGraph = sig
-  module Weight : sig
+  module Distance : sig
     type t
     val zero : t
     val compare : t -> t -> int
@@ -10,7 +10,7 @@ module type WeightedDirectedGraph = sig
     (* グラフに含まれる頂点の集合 *)
     val universe : set
     (* 最短経路を求めたいグラフの，ある頂点から伸びる辺に対してのイテレータ *)
-    val iter_adjacency : t -> (t -> (Weight.t -> Weight.t) (* 辺を通った際のコストを加算する関数 *) -> unit) -> unit
+    val iter_adjacency : t -> (t -> (Distance.t -> Distance.t) (* 辺を通った際の距離を加算する関数 *) -> unit) -> unit
   end
 end
 
@@ -48,16 +48,20 @@ module F
     val take_min_binding : t -> (key * elt) option
   end)
 : sig
+  type vertex = Array.key
+  type distance = Array.elt
+  type vertices = Array.size
+
   (* ダイクストラ法で最短経路を求める関数 *)
   val shortest_path :
     (module WeightedDirectedGraph
-      with type Weight.t = Array.elt
-       and type Vertex.t = Array.key
-       and type Vertex.set = Array.size) ->
+      with type Vertex.t = vertex
+       and type Vertex.set = vertices
+       and type Distance.t = distance) ->
     (* 始点 *)
-    Array.key ->
+    vertex ->
     (* 終点を受け取って，始点からの最短距離を返す関数
        始点から辿り着けない場合，無限大を返す
        この関数を覚えておけば，呼び出しごとの途中までの計算結果がシェアされる *)
-    (Array.key -> Array.elt)
+    (vertex -> distance)
 end

--- a/lib/graph/dijkstra.mli
+++ b/lib/graph/dijkstra.mli
@@ -1,16 +1,38 @@
-module F
-  (* 辺の重み *)
-  (Weight : sig
+module type WeightedDirectedGraph = sig
+  module Weight : sig
     type t
     val zero : t
     val compare : t -> t -> int
+  end
+  module Vertex : sig
+    type t
+    type set
+    (* グラフに含まれる頂点の集合 *)
+    val universe : set
+    (* 最短経路を求めたいグラフの，ある頂点から伸びる辺に対してのイテレータ *)
+    val iter_adjacency : t -> (t -> (Weight.t -> Weight.t) (* 辺を通った際のコストを加算する関数 *) -> unit) -> unit
+  end
+end
+
+module F
+  (* 頂点を添字，経路長を要素とした配列の実装 *)
+  (Array : sig
+    type t
+    type key
+    type elt
+    type size
+
+    (* 全ての頂点についての経路長が無限大で初期化された配列を作る *)
+    val make : size -> t
+    val get : t -> key -> elt
+    val set : t -> key -> elt -> unit
   end)
   (* 経路長を優先度としたヒープの実装 *)
   (Heap : sig
     type t
-    type elt
-    type key = Weight.t (* 経路長に相当 *)
-    type size
+    type elt = Array.key
+    type key = Array.elt (* 経路長に相当 *)
+    type size = Array.size
 
     (* 空なヒープを作成する *)
     val make : size -> t
@@ -25,33 +47,17 @@ module F
        返した binding はヒープから削除される *)
     val take_min_binding : t -> (key * elt) option
   end)
-  (* 頂点を添字，経路長を要素とした配列の実装 *)
-  (Array : sig
-    type t
-    type key = Heap.elt
-    type elt = Heap.key
-    type size = Heap.size
-
-    (* 全ての頂点についての経路長が無限大で初期化された配列を作る *)
-    val make : size -> t
-    val get : t -> key -> elt
-    val set : t -> key -> elt -> unit
-  end)
 : sig
-  type weight = Array.elt
-  type vertex = Array.key
-  type vertices = Array.size
-
   (* ダイクストラ法で最短経路を求める関数 *)
   val shortest_path :
-    (* グラフに含まれる頂点の集合 *)
-    vertices ->
-    (* 最短経路を求めたいグラフの，ある頂点から伸びる辺に対してのイテレータ *)
-    (vertex -> (vertex -> (weight -> weight) (* 辺を通った際のコストを加算する関数 *) -> unit) -> unit) ->
+    (module WeightedDirectedGraph
+      with type Weight.t = Array.elt
+       and type Vertex.t = Array.key
+       and type Vertex.set = Array.size) ->
     (* 始点 *)
-    vertex ->
+    Array.key ->
     (* 終点を受け取って，始点からの最短距離を返す関数
        始点から辿り着けない場合，無限大を返す
        この関数を覚えておけば，呼び出しごとの途中までの計算結果がシェアされる *)
-    (vertex -> weight)
+    (Array.key -> Array.elt)
 end

--- a/lib/graph/dijkstra.mli
+++ b/lib/graph/dijkstra.mli
@@ -10,7 +10,7 @@ module type WeightedDirectedGraph = sig
     (* グラフに含まれる頂点の集合 *)
     val universe : set
     (* 最短経路を求めたいグラフの，ある頂点から伸びる辺に対してのイテレータ *)
-    val iter_adjacency : t -> (t -> (Distance.t -> Distance.t) (* 辺を通った際の距離を加算する関数 *) -> unit) -> unit
+    val iter_adjacencies : t -> (t -> (Distance.t -> Distance.t) (* 辺を通った際の距離を加算する関数 *) -> unit) -> unit
   end
 end
 

--- a/lib/graph/dinic.ml
+++ b/lib/graph/dinic.ml
@@ -74,9 +74,18 @@ module F
         find () in
 
     let rec outer flow =
-      let level = Fun.flip (G.shortest_path n) s @@ fun v f ->
-        Fun.flip List.iter (Array.get adj v) @@ fun e ->
-          if 0 < Flow.compare e.capacity Flow.zero then f e.dst in
+      let level =
+        G.shortest_path
+          (module struct
+            module Vertex = struct
+              type t = vertex
+              type set = vertices
+              let universe = n
+              let iter_adjacency v f =
+                Fun.flip List.iter (Array.get adj v) @@ fun e ->
+                  if 0 < Flow.compare e.capacity Flow.zero then f e.dst
+            end
+          end) s in
       if max_int <= level t
       then flow
       else

--- a/lib/graph/dinic.ml
+++ b/lib/graph/dinic.ml
@@ -81,7 +81,7 @@ module F
               type t = vertex
               type set = vertices
               let universe = n
-              let iter_adjacency v f =
+              let iter_adjacencies v f =
                 Fun.flip List.iter (Array.get adj v) @@ fun e ->
                   if 0 < Flow.compare e.capacity Flow.zero then f e.dst
             end

--- a/lib/graph/prim.ml
+++ b/lib/graph/prim.ml
@@ -32,7 +32,7 @@ module type UnrootedWeightedTree = sig
     type t
     val weight : t -> Weight.t
     val endpoint : t -> Vertex.t
-    val universe_fold : (t -> 'a -> 'a) -> 'a -> 'a
+    val fold_universe : (t -> 'a -> 'a) -> 'a -> 'a
   end
 end
 
@@ -72,7 +72,7 @@ module F
       module Vertex = G.Vertex
       module Edge = struct
         include G.Edge
-        let universe_fold f acc =
+        let fold_universe f acc =
           let q = Heap.make G.Vertex.universe in
           let d = Array.make G.Vertex.universe in
           let rec prim acc u =

--- a/lib/graph/prim.mli
+++ b/lib/graph/prim.mli
@@ -46,8 +46,9 @@ module type UnrootedWeightedTree = sig
     val weight : t -> Weight.t
     (* 辺の端点の一つ *)
     val endpoint : t -> Vertex.t
+    (* グラフに含まれる全ての辺を畳み込む *)
+    val universe_fold : (t -> 'a -> 'a) -> 'a -> 'a
   end
-  val fold_edges : (Edge.t -> 'a -> 'a) -> 'a -> 'a
 end
 
 module F

--- a/lib/graph/prim.mli
+++ b/lib/graph/prim.mli
@@ -47,7 +47,7 @@ module type UnrootedWeightedTree = sig
     (* 辺の端点の一つ *)
     val endpoint : t -> Vertex.t
     (* グラフに含まれる全ての辺を畳み込む *)
-    val universe_fold : (t -> 'a -> 'a) -> 'a -> 'a
+    val fold_universe : (t -> 'a -> 'a) -> 'a -> 'a
   end
 end
 

--- a/lib/graph/scc.ml
+++ b/lib/graph/scc.ml
@@ -3,7 +3,7 @@ module type UnweightedDirectedGraph = sig
     type t
     type set
     val universe : set
-    val universe_fold : (t -> 'a -> 'a) -> 'a -> 'a
+    val fold_universe : (t -> 'a -> 'a) -> 'a -> 'a
     val fold_adjacencies : t -> (t -> 'a -> 'a) -> 'a -> 'a
   end
 end
@@ -44,7 +44,7 @@ module F
       with type Vertex.t = vertex
        and type Vertex.set = vertices) =
     let vs = Array.make G.Vertex.universe in
-    G.Vertex.universe_fold (visit (module L) (module G) vs) L.nil
+    G.Vertex.fold_universe (visit (module L) (module G) vs) L.nil
 
   let scc (type l) (type ll)
     (module L : List with type t = l and type elt = vertex)

--- a/lib/graph/scc.ml
+++ b/lib/graph/scc.ml
@@ -1,35 +1,65 @@
-module F
-  (Vertices : sig
+module type UnweightedDirectedGraph = sig
+  module Vertex : sig
     type t
-    type vertex
-    val fold : (vertex -> 'a -> 'a) -> t -> 'a -> 'a
-  end)
+    type set
+    val universe : set
+    val universe_fold : (t -> 'a -> 'a) -> 'a -> 'a
+    val fold_adjacencies : t -> (t -> 'a -> 'a) -> 'a -> 'a
+  end
+end
+
+module type List = sig
+  type t
+  type elt
+  val nil : t
+  val cons : elt -> t -> t
+end
+
+module F
   (Array : sig
     type t
     type elt = bool
-    type key = Vertices.vertex
-    type size = Vertices.t
+    type key
+    type size
     val make : size -> t
     val get : t -> key -> elt
     val set : t -> key -> elt -> unit
   end)
 = struct
-  type vertex = Vertices.vertex
-  type vertices = Vertices.t
+  type vertex = Array.key
+  type vertices = Array.size
 
-  let rec visit es vs v l =
-    if Array.get vs v
-    then l
-    else (Array.set vs v true; v :: List.fold_right (visit es vs) (es v) l)
-
-  let sort n es =
-    let vs = Array.make n in
-    Vertices.fold (visit es vs) n []
-
-  let scc n es =
-    let vs = Array.make n in
-    List.fold_right (fun v l ->
+  let visit (type l)
+    (module L : List with type t = l and type elt = vertex)
+    (module G : UnweightedDirectedGraph with type Vertex.t = vertex) vs =
+    let rec visit v l =
       if Array.get vs v
       then l
-      else visit es vs v [] :: l) (sort n es) []
+      else (Array.set vs v true; L.cons v (G.Vertex.fold_adjacencies v visit l)) in
+    visit
+
+  let sort (type l)
+    (module L : List with type t = l and type elt = vertex)
+    (module G : UnweightedDirectedGraph
+      with type Vertex.t = vertex
+       and type Vertex.set = vertices) =
+    let vs = Array.make G.Vertex.universe in
+    G.Vertex.universe_fold (visit (module L) (module G) vs) L.nil
+
+  let scc (type l) (type ll)
+    (module L : List with type t = l and type elt = vertex)
+    (module LL : List with type t = ll and type elt = l)
+    (module G : UnweightedDirectedGraph
+      with type Vertex.t = vertex
+       and type Vertex.set = vertices) =
+    let vs = Array.make G.Vertex.universe in
+    sort
+      (module struct
+        include LL
+        type elt = vertex
+        let cons v l =
+          if Array.get vs v
+          then l
+          else LL.cons (visit (module L) (module G) vs v L.nil) l
+      end) (module G)
 end

--- a/lib/graph/scc.mli
+++ b/lib/graph/scc.mli
@@ -6,7 +6,7 @@ module type UnweightedDirectedGraph = sig
     (* グラフに含まれる頂点の集合 *)
     val universe : set
     (* 頂点に含まれる集合の畳み込み *)
-    val universe_fold : (t -> 'a -> 'a) -> 'a -> 'a
+    val fold_universe : (t -> 'a -> 'a) -> 'a -> 'a
     (* 隣接する頂点の畳み込み *)
     val fold_adjacencies : t -> (t -> 'a -> 'a) -> 'a -> 'a
   end

--- a/lib/graph/scc.mli
+++ b/lib/graph/scc.mli
@@ -1,39 +1,61 @@
-module F
-  (Vertices : sig
-    (* グラフに含まれる頂点の集合 *)
+(* 重み付き無向グラフ *)
+module type UnweightedDirectedGraph = sig
+  module Vertex : sig
     type t
-    type vertex
-    (* グラフに含まれる頂点の集合に対するfold *)
-    val fold : (vertex -> 'a -> 'a) -> t -> 'a -> 'a
-  end)
+    type set
+    (* グラフに含まれる頂点の集合 *)
+    val universe : set
+    (* 頂点に含まれる集合の畳み込み *)
+    val universe_fold : (t -> 'a -> 'a) -> 'a -> 'a
+    (* 隣接する頂点の畳み込み *)
+    val fold_adjacencies : t -> (t -> 'a -> 'a) -> 'a -> 'a
+  end
+end
+
+(* リスト *)
+module type List = sig
+  type t
+  type elt
+  val nil : t
+  val cons : elt -> t -> t
+end
+
+module F
   (* 頂点を添字，真偽値を要素とした配列の実装 *)
   (Array : sig
     type t
     type elt = bool
-    type key = Vertices.vertex
-    type size = Vertices.t
+    type key
+    type size
     (* falseで初期化された配列を作成する *)
     val make : size -> t
     val get : t -> key -> elt
     val set : t -> key -> elt -> unit
   end)
 : sig
-  type vertex = Vertices.vertex
-  type vertices = Vertices.t
+  type vertex = Array.key
+  type vertices = Array.size
   
   (* トポロジカルソート *)
   val sort :
-    (* グラフに含まれる頂点の集合 *)
-    vertices ->
-    (* 隣接リスト *)
-    (vertex -> vertex list) ->
-    vertex list
+    (* 頂点のリスト *)
+    (module List with type elt = vertex and type t = 'l) ->
+    (* 有向グラフ *)
+    (module UnweightedDirectedGraph
+      with type Vertex.t = vertex
+       and type Vertex.set = vertices) ->
+    (* 頂点をトポロジカルソートしたリスト *)
+    'l
 
   (* 強連結成分分解 *)
   val scc :
-    (* グラフに含まれる頂点の集合 *)
-    vertices ->
-    (* 隣接リスト *)
-    (vertex -> vertex list) ->
-    vertex list list
+    (* 頂点のリスト *)
+    (module List with type elt = vertex and type t = 'l) ->
+    (* 頂点のリストのリスト *)
+    (module List with type elt = 'l and type t = 'll) ->
+    (* 有向グラフ *)
+    (module UnweightedDirectedGraph
+      with type Vertex.t = vertex
+       and type Vertex.set = vertices) ->
+    'll
 end

--- a/lib/graph/scc.mli
+++ b/lib/graph/scc.mli
@@ -20,42 +20,54 @@ module type List = sig
   val cons : elt -> t -> t
 end
 
+module type Array = sig
+  type t
+  type elt
+  type key
+  type size
+  val make : size -> t
+  val get : t -> key -> elt
+  val set : t -> key -> elt -> unit
+end
+
 module F
-  (* 頂点を添字，真偽値を要素とした配列の実装 *)
-  (Array : sig
-    type t
-    type elt = bool
-    type key
-    type size
-    (* falseで初期化された配列を作成する *)
-    val make : size -> t
-    val get : t -> key -> elt
-    val set : t -> key -> elt -> unit
-  end)
+  (* 頂点を添字，真偽値を要素とした配列の実装
+     A.make は false で初期化された配列を返さなくてはならない *)
+  (A : Array with type elt = bool)
+  (* 頂点のリスト *)
+  (L : List with type elt = A.key)
 : sig
-  type vertex = Array.key
-  type vertices = Array.size
-  
+  type vertex = A.key
+  type vertices = A.size
+
   (* トポロジカルソート *)
   val sort :
-    (* 頂点のリスト *)
-    (module List with type elt = vertex and type t = 'l) ->
     (* 有向グラフ *)
     (module UnweightedDirectedGraph
       with type Vertex.t = vertex
        and type Vertex.set = vertices) ->
     (* 頂点をトポロジカルソートしたリスト *)
-    'l
+    L.t
+end
+
+module G
+  (* 頂点を添字，真偽値を要素とした配列の実装
+     A.make は false で初期化された配列を返さなくてはならない *)
+  (A : Array with type elt = bool)
+  (* 頂点のリスト *)
+  (L : List with type elt = A.key)
+  (* 頂点のリストのリスト *)
+  (LL : List with type elt = L.t)
+: sig
+  type vertex = A.key
+  type vertices = A.size
 
   (* 強連結成分分解 *)
   val scc :
-    (* 頂点のリスト *)
-    (module List with type elt = vertex and type t = 'l) ->
-    (* 頂点のリストのリスト *)
-    (module List with type elt = 'l and type t = 'll) ->
     (* 有向グラフ *)
     (module UnweightedDirectedGraph
       with type Vertex.t = vertex
        and type Vertex.set = vertices) ->
-    'll
+    (* 強連結成分のリスト *)
+    LL.t
 end

--- a/test/graph/bellmanFord.ml
+++ b/test/graph/bellmanFord.ml
@@ -1,14 +1,22 @@
 (* sample code *)
 
-module G = Compelib.BellmanFord.F (Int)
-  (struct
-    type t = int
-    let zero = 0
-    let inf = max_int
-    let neg_inf = min_int
-    let ( + ) = ( + )
-    let compare = compare
-  end)
+module V = struct
+  type t = int
+  type set = int
+  let universe = 8
+  let cardinal_universe = 8
+  let compare = compare
+end
+
+module D = struct
+  type t = int
+  let zero = 0
+  let inf = max_int
+  let neg_inf = min_int
+  let compare = compare
+end
+
+module G = Compelib.BellmanFord.F
   (struct
     type t = int array
     type key = int
@@ -17,23 +25,49 @@ module G = Compelib.BellmanFord.F (Int)
     let make = Fun.flip Array.make max_int
     let get = Array.get
     let set = Array.set
-    let size_to_int = Fun.id
   end)
 
 let%test _ =
-  List.init 8 (G.shortest_path 8
-    (List.map (fun (u, v, c) -> (u, v, ( + ) c))
-    [ (1, 2, 1); (2, 3, 1); (3, 7, 1); (4, 5, -1); (5, 6, -1); (6, 4, -1) ]) 1) =
-  [ max_int; 0; 1; 2; max_int; max_int; max_int; 3]
+  List.init 8 (G.shortest_path
+    (module struct
+      module Vertex = V
+      module Distance = D
+      module Edge = struct
+        type t = int * int * int
+        let source (u, _, _) = u
+        let destination (_, v, _) = v
+        let add_weight (_, _, c) = ( + ) c
+        let universe = [ (1, 2, 1); (2, 3, 1); (3, 7, 1); (4, 5, -1); (5, 6, -1); (6, 4, -1) ]
+      end
+    end) 1)
+  = [ max_int; 0; 1; 2; max_int; max_int; max_int; 3]
 
 let%test _ =
-  List.init 8 (G.shortest_path 8
-    (List.map (fun (u, v, c) -> (u, v, ( + ) c))
-    [ (1, 2, 1); (2, 3, 1); (3, 7, 1); (4, 5, -1); (5, 6, -1); (6, 4, -1); (7, 4, -1) ]) 1) =
-  [max_int; 0; 1; 2; min_int; min_int; min_int; 3]
+  List.init 8 (G.shortest_path
+    (module struct
+      module Vertex = V
+      module Distance = D
+      module Edge = struct
+        type t = int * int * int
+        let source (u, _, _) = u
+        let destination (_, v, _) = v
+        let add_weight (_, _, c) = ( + ) c
+        let universe = [ (1, 2, 1); (2, 3, 1); (3, 7, 1); (4, 5, -1); (5, 6, -1); (6, 4, -1); (7, 4, -1) ]
+      end
+    end) 1)
+  = [max_int; 0; 1; 2; min_int; min_int; min_int; 3]
 
 let%test _ =
-  List.init 8 (G.shortest_path 8
-    (List.map (fun (u, v, c) -> (u, v, ( + ) c))
-    [ (1, 2, 1); (2, 3, 1); (3, 7, 1); (4, 5, -1); (5, 6, -1); (6, 4, -1); (7, 4, -1); (4, 7, 1) ]) 1) =
-  [max_int; 0; 1; 2; min_int; min_int; min_int; min_int]
+  List.init 8 (G.shortest_path
+    (module struct
+      module Vertex = V
+      module Distance = D
+      module Edge = struct
+        type t = int * int * int
+        let source (u, _, _) = u
+        let destination (_, v, _) = v
+        let add_weight (_, _, c) = ( + ) c
+        let universe = [ (1, 2, 1); (2, 3, 1); (3, 7, 1); (4, 5, -1); (5, 6, -1); (6, 4, -1); (7, 4, -1); (4, 7, 1) ]
+      end
+    end) 1)
+  = [max_int; 0; 1; 2; min_int; min_int; min_int; min_int]

--- a/test/graph/bfs.ml
+++ b/test/graph/bfs.ml
@@ -15,13 +15,20 @@ let maze =
     "..##..";
     "#....."|]
 
-let d = G.shortest_path [| 6; 5 |]
-  (fun [| i; j |] f ->
-    List.iter (fun ([| i; j |] as v) ->
-      match maze.(j).[i] = '.' with
-      | false | exception (Invalid_argument _) -> ()
-      | true -> f v)
-    [ [| i + 1; j |]; [| i - 1; j |]; [| i; j + 1 |]; [| i; j - 1 |] ]) [| 0; 0 |]
+let d = G.shortest_path
+  (module struct
+    module Vertex = struct
+      type t = int array
+      type set = int array
+      let universe = [| 6; 5 |]
+      let iter_adjacency [| i; j |] f =
+        List.iter (fun ([| i; j |] as v) ->
+          match maze.(j).[i] = '.' with
+          | false | exception (Invalid_argument _) -> ()
+          | true -> f v)
+        [ [| i + 1; j |]; [| i - 1; j |]; [| i; j + 1 |]; [| i; j - 1 |] ]
+    end
+  end) [| 0; 0 |]
 
 let%test _ = d [| 5; 0 |] = 5
 let%test _ = d [| 3; 2 |] = max_int

--- a/test/graph/bfs.ml
+++ b/test/graph/bfs.ml
@@ -21,7 +21,7 @@ let d = G.shortest_path
       type t = int array
       type set = int array
       let universe = [| 6; 5 |]
-      let iter_adjacency [| i; j |] f =
+      let iter_adjacencies [| i; j |] f =
         List.iter (fun ([| i; j |] as v) ->
           match maze.(j).[i] = '.' with
           | false | exception (Invalid_argument _) -> ()

--- a/test/graph/dijkstra.ml
+++ b/test/graph/dijkstra.ml
@@ -43,7 +43,7 @@ let e =
 let%test _ =
   List.init 7 (G.shortest_path
     (module struct
-      module Weight = Int
+      module Distance = Int
       module Vertex = struct
         type t = int
         type set = int
@@ -82,7 +82,7 @@ module G' = Compelib.Dijkstra.F
 let%test _ =
   List.init 10 (G'.shortest_path
     (module struct
-      module Weight = Int
+      module Distance = Int
       module Vertex = struct
         type t = int
         type set = unit
@@ -96,7 +96,7 @@ let%test _ =
 let%test _ =
   List.init 10 (G'.shortest_path
     (module struct
-      module Weight = Int
+      module Distance = Int
       module Vertex = struct
         type t = int
         type set = unit

--- a/test/graph/dijkstra.ml
+++ b/test/graph/dijkstra.ml
@@ -48,7 +48,7 @@ let%test _ =
         type t = int
         type set = int
         let universe = 7
-        let iter_adjacency u f = Fun.flip List.iter e.(u) @@ fun (v, c) -> f v @@ ( + ) c
+        let iter_adjacencies u f = Fun.flip List.iter e.(u) @@ fun (v, c) -> f v @@ ( + ) c
       end
     end) 0)
   = [ 0; 7; 9; 20; 20; 11; max_int ]
@@ -87,7 +87,7 @@ let%test _ =
         type t = int
         type set = unit
         let universe = ()
-        let iter_adjacency u f = Fun.flip List.iter e.(u) @@ fun (v, c) -> f v @@ ( + ) c
+        let iter_adjacencies u f = Fun.flip List.iter e.(u) @@ fun (v, c) -> f v @@ ( + ) c
       end
     end) 0)
   = [ 0; 7; 9; 20; 20; 11; max_int; max_int; max_int; max_int ]
@@ -101,7 +101,7 @@ let%test _ =
         type t = int
         type set = unit
         let universe = ()
-        let iter_adjacency u f = f (u + 1) succ
+        let iter_adjacencies u f = f (u + 1) succ
       end
     end) 0)
   = [0; 1; 2; 3; 4; 5; 6; 7; 8; 9]

--- a/test/graph/dijkstra.ml
+++ b/test/graph/dijkstra.ml
@@ -7,7 +7,16 @@ end
 
 module IntMap = Map.Make (Int)
 
-module G = Compelib.Dijkstra.F (Int)
+module G = Compelib.Dijkstra.F
+  (struct
+    type t = int array
+    type key = int
+    type elt = int
+    type size = int
+    let make = Fun.flip Array.make max_int
+    let get = Array.get
+    let set = Array.set
+  end)
   (struct
     type t = int list IntMap.t ref
     type elt = int
@@ -22,15 +31,6 @@ module G = Compelib.Dijkstra.F (Int)
     let add q w v  =
       q := IntMap.update w (fun vs -> Some (v :: Option.value ~default:[] vs)) !q
   end)
-  (struct
-    type t = int array
-    type key = int
-    type elt = int
-    type size = int
-    let make = Fun.flip Array.make max_int
-    let get = Array.get
-    let set = Array.set
-  end)
 
 let e =
   [|[ (1, 7); (2, 9); (5, 14) ];
@@ -41,13 +41,29 @@ let e =
     [ (0, 14); (2, 2); (4, 9) ]|]
 
 let%test _ =
-  ( = ) [ 0; 7; 9; 20; 20; 11; max_int ] @@
-  List.init 7 @@
-  Fun.flip (G.shortest_path 7) 0 @@
-  fun u f -> Fun.flip List.iter e.(u) @@ fun (v, c) -> f v @@ ( + ) c
+  List.init 7 (G.shortest_path
+    (module struct
+      module Weight = Int
+      module Vertex = struct
+        type t = int
+        type set = int
+        let universe = 7
+        let iter_adjacency u f = Fun.flip List.iter e.(u) @@ fun (v, c) -> f v @@ ( + ) c
+      end
+    end) 0)
+  = [ 0; 7; 9; 20; 20; 11; max_int ]
 
 (* 経路長をMapに保存する *)
-module G' = Compelib.Dijkstra.F (Int)
+module G' = Compelib.Dijkstra.F
+  (struct
+    type t = int IntMap.t ref
+    type key = int
+    type elt = int
+    type size = unit
+    let make () = ref IntMap.empty
+    let get m k = try IntMap.find k !m with Not_found -> max_int
+    let set m k x = m := IntMap.add k x !m
+  end)
   (struct
     type t = int list IntMap.t ref
     type elt = int
@@ -62,25 +78,30 @@ module G' = Compelib.Dijkstra.F (Int)
     let add q w v  =
       q := IntMap.update w (fun vs -> Some (v :: Option.value ~default:[] vs)) !q
   end)
-  (struct
-    type t = int IntMap.t ref
-    type key = int
-    type elt = int
-    type size = unit
-    let make () = ref IntMap.empty
-    let get m k = try IntMap.find k !m with Not_found -> max_int
-    let set m k x = m := IntMap.add k x !m
-  end)
 
 let%test _ =
-  ( = ) [ 0; 7; 9; 20; 20; 11; max_int; max_int; max_int; max_int ] @@
-  List.init 10 @@
-  Fun.flip (G'.shortest_path ()) 0 @@
-  fun u f -> Fun.flip List.iter e.(u) @@ fun (v, c) -> f v @@ ( + ) c
+  List.init 10 (G'.shortest_path
+    (module struct
+      module Weight = Int
+      module Vertex = struct
+        type t = int
+        type set = unit
+        let universe = ()
+        let iter_adjacency u f = Fun.flip List.iter e.(u) @@ fun (v, c) -> f v @@ ( + ) c
+      end
+    end) 0)
+  = [ 0; 7; 9; 20; 20; 11; max_int; max_int; max_int; max_int ]
 
 (* 無限グラフも可 *)
 let%test _ =
-  ( = ) [0; 1; 2; 3; 4; 5; 6; 7; 8; 9] @@
-  List.init 10 @@ 
-  Fun.flip (G'.shortest_path ()) 0 @@
-  fun u f -> f (u + 1) @@ ( + ) 1
+  List.init 10 (G'.shortest_path
+    (module struct
+      module Weight = Int
+      module Vertex = struct
+        type t = int
+        type set = unit
+        let universe = ()
+        let iter_adjacency u f = f (u + 1) succ
+      end
+    end) 0)
+  = [0; 1; 2; 3; 4; 5; 6; 7; 8; 9]

--- a/test/graph/pathReconstr.ml
+++ b/test/graph/pathReconstr.ml
@@ -50,7 +50,7 @@ let d =
         type t = int
         type set = int
         let universe = 7
-        let iter_adjacency u f = Fun.flip List.iter e.(u) @@ fun (v, c) -> f v @@ ( + ) c
+        let iter_adjacencies u f = Fun.flip List.iter e.(u) @@ fun (v, c) -> f v @@ ( + ) c
       end
     end) 0
 

--- a/test/graph/pathReconstr.ml
+++ b/test/graph/pathReconstr.ml
@@ -9,7 +9,16 @@ end
 
 module IntMap = Map.Make (Int)
 
-module G = Compelib.Dijkstra.F (Int)
+module G = Compelib.Dijkstra.F
+  (struct
+    type t = int array
+    type key = int
+    type elt = int
+    type size = int
+    let make = Fun.flip Array.make max_int
+    let get = Array.get
+    let set = Array.set
+  end)
   (struct
     type t = int list IntMap.t ref
     type elt = int
@@ -24,15 +33,6 @@ module G = Compelib.Dijkstra.F (Int)
     let add q w v  =
       q := IntMap.update w (fun vs -> Some (v :: Option.value ~default:[] vs)) !q
   end)
-  (struct
-    type t = int array
-    type key = int
-    type elt = int
-    type size = int
-    let make = Fun.flip Array.make max_int
-    let get = Array.get
-    let set = Array.set
-  end)
 
 let e =
   [|[ (1, 7); (2, 9); (5, 14) ];
@@ -43,8 +43,16 @@ let e =
     [ (0, 14); (2, 2); (4, 9) ]|]
 
 let d =
-  Fun.flip (G.shortest_path 6) 0 @@
-  fun u f -> Fun.flip List.iter e.(u) @@ fun (v, c) -> f v @@ ( + ) c
+  G.shortest_path
+    (module struct
+      module Weight = Int
+      module Vertex = struct
+        type t = int
+        type set = int
+        let universe = 7
+        let iter_adjacency u f = Fun.flip List.iter e.(u) @@ fun (v, c) -> f v @@ ( + ) c
+      end
+    end) 0
 
 (* 経路復元を行う *)
 

--- a/test/graph/pathReconstr.ml
+++ b/test/graph/pathReconstr.ml
@@ -45,7 +45,7 @@ let e =
 let d =
   G.shortest_path
     (module struct
-      module Weight = Int
+      module Distance = Int
       module Vertex = struct
         type t = int
         type set = int

--- a/test/graph/prim.ml
+++ b/test/graph/prim.ml
@@ -59,7 +59,7 @@ let%test _ =
         let endpoint = fst
       end
     end) 0) in
-  T.Edge.universe_fold (fun (_, w) -> ( + ) w) 0 = 39
+  T.Edge.fold_universe (fun (_, w) -> ( + ) w) 0 = 39
 
 (* 使った辺を列挙したい場合 *)
 
@@ -104,5 +104,5 @@ let%test _ =
         let endpoint (_, v, _) = v
       end
     end) 0) in
-  List.sort compare (T.Edge.universe_fold (fun (u, v, w) -> List.cons (min u v, max u v, w)) [])
+  List.sort compare (T.Edge.fold_universe (fun (u, v, w) -> List.cons (min u v, max u v, w)) [])
   = [(0, 1, 7); (0, 3, 5); (1, 4, 7); (2, 4, 5); (3, 5, 6); (4, 6, 9)]

--- a/test/graph/prim.ml
+++ b/test/graph/prim.ml
@@ -59,7 +59,7 @@ let%test _ =
         let endpoint = fst
       end
     end) 0) in
-  T.fold_edges (fun (_, w) -> ( + ) w) 0 = 39
+  T.Edge.universe_fold (fun (_, w) -> ( + ) w) 0 = 39
 
 (* 使った辺を列挙したい場合 *)
 
@@ -104,5 +104,5 @@ let%test _ =
         let endpoint (_, v, _) = v
       end
     end) 0) in
-  List.sort compare (T.fold_edges (fun (u, v, w) -> List.cons (min u v, max u v, w)) [])
+  List.sort compare (T.Edge.universe_fold (fun (u, v, w) -> List.cons (min u v, max u v, w)) [])
   = [(0, 1, 7); (0, 3, 5); (1, 4, 7); (2, 4, 5); (3, 5, 6); (4, 6, 9)]

--- a/test/graph/scc.ml
+++ b/test/graph/scc.ml
@@ -1,14 +1,4 @@
-(* sample code *)
-
-module IntG = Compelib.Scc.F
-  (struct
-    type t = int
-    type vertex = int
-    let rec fold f n acc =
-      if n = 0
-      then acc
-      else fold f (n - 1) (f n acc)
-  end)
+module M = Compelib.Scc.F
   (struct
     type t = bool array
     type key = int
@@ -19,26 +9,46 @@ module IntG = Compelib.Scc.F
     let set = Array.set
   end)
 
-let%test _ =
-  List.map (List.sort_uniq compare)
-    [[2; 3; 1]; [4; 5]; [6]; [7]] =
-  List.map (List.sort_uniq compare)
-    (IntG.scc 7 (function
-      | 1 -> [2]
-      | 2 -> [3]
-      | 3 -> [1; 4]
-      | 4 -> [5]
-      | 5 -> [4; 6; 7]
-      | 6 -> []
-      | 7 -> []))
+module L = struct
+  type t = int list
+  type elt = int
+  let nil = []
+  let cons = List.cons
+end
+
+module LL = struct
+  type t = int list list
+  type elt = int list
+  let nil = []
+  let cons = List.cons
+end
+
+module G = struct
+  module Vertex = struct
+    type t = int
+    type set = int
+    let universe = 7
+    let rec foldn n f acc =
+      if n = 0
+      then acc
+      else foldn (n - 1) f (f n acc)
+    let universe_fold f acc = foldn universe f acc
+    let fold_adjacencies v f acc =
+      List.fold_right f
+        begin match v with
+        | 1 -> [2]
+        | 2 -> [3]
+        | 3 -> [1; 4]
+        | 4 -> [5]
+        | 5 -> [4; 6; 7]
+        | 6 -> []
+        | 7 -> []
+        end acc
+  end
+end
 
 let%test _ =
-  IntG.sort 7 (function
-    | 1 -> [2]
-    | 2 -> [3]
-    | 3 -> [1; 4]
-    | 4 -> [5]
-    | 5 -> [4; 6; 7]
-    | 6 -> []
-    | 7 -> []) =
-  [3; 1; 2; 5; 4; 6; 7]
+  List.map (List.sort_uniq compare) (M.scc (module L) (module LL) (module G))
+  = List.map (List.sort_uniq compare) [[2; 3; 1]; [4; 5]; [6]; [7]]
+
+let%test _ = M.sort (module L) (module G) = [3; 1; 2; 5; 4; 6; 7]

--- a/test/graph/scc.ml
+++ b/test/graph/scc.ml
@@ -1,13 +1,12 @@
-module M = Compelib.Scc.F
-  (struct
-    type t = bool array
-    type key = int
-    type elt = bool
-    type size = int
-    let make n = Array.make (n + 1) false
-    let get = Array.get
-    let set = Array.set
-  end)
+module A = struct
+  type t = bool array
+  type key = int
+  type elt = bool
+  type size = int
+  let make n = Array.make (n + 1) false
+  let get = Array.get
+  let set = Array.set
+end
 
 module L = struct
   type t = int list
@@ -22,6 +21,9 @@ module LL = struct
   let nil = []
   let cons = List.cons
 end
+
+module M = Compelib.Scc.F (A) (L)
+module N = Compelib.Scc.G (A) (L) (LL)
 
 module G = struct
   module Vertex = struct
@@ -48,7 +50,7 @@ module G = struct
 end
 
 let%test _ =
-  List.map (List.sort_uniq compare) (M.scc (module L) (module LL) (module G))
+  List.map (List.sort_uniq compare) (N.scc (module G))
   = List.map (List.sort_uniq compare) [[2; 3; 1]; [4; 5]; [6]; [7]]
 
-let%test _ = M.sort (module L) (module G) = [3; 1; 2; 5; 4; 6; 7]
+let%test _ = M.sort (module G) = [3; 1; 2; 5; 4; 6; 7]

--- a/test/graph/scc.ml
+++ b/test/graph/scc.ml
@@ -32,7 +32,7 @@ module G = struct
       if n = 0
       then acc
       else foldn (n - 1) f (f n acc)
-    let universe_fold f acc = foldn universe f acc
+    let fold_universe f acc = foldn universe f acc
     let fold_adjacencies v f acc =
       List.fold_right f
         begin match v with


### PR DESCRIPTION
頂点に関するモジュールやら辺の重みに関するモジュールやらと個別に扱っていると引数がかさんでしまうので，
グラフに関連するモジュールをひとまとめにして引数にしてしまう．